### PR TITLE
do not addRef on implicit objects

### DIFF
--- a/data.go
+++ b/data.go
@@ -25,6 +25,7 @@ import (
 type Data struct {
 	ObjectType    ObjectType
 	dpiData       C.dpiData
+	implicitObj   bool
 	NativeTypeNum C.dpiNativeTypeNum
 }
 
@@ -196,8 +197,10 @@ func (d *Data) GetObject() *Object {
 	if o == nil {
 		return nil
 	}
-	if C.dpiObject_addRef(o) == C.DPI_FAILURE {
-		panic(d.ObjectType.getError())
+	if !d.implicitObj {
+		if C.dpiObject_addRef(o) == C.DPI_FAILURE {
+			panic(d.ObjectType.getError())
+		}
 	}
 	obj := &Object{dpiObject: o, ObjectType: d.ObjectType}
 	obj.init()

--- a/data.go
+++ b/data.go
@@ -461,6 +461,7 @@ func newVarInfo(baseType interface{}, sliceLen, bufSize int) (varInfo, error) {
 func (d *Data) reset() {
 	d.NativeTypeNum = 0
 	d.ObjectType = ObjectType{}
+	d.implicitObj = false
 	d.SetBytes(nil)
 	d.dpiData.isNull = 1
 }

--- a/data.go
+++ b/data.go
@@ -373,10 +373,11 @@ func (c *conn) NewData(baseType interface{}, sliceLen, bufSize int) ([]*Data, er
 		return nil, err
 	}
 
-	_, dpiData, err := c.newVar(vi)
+	v, dpiData, err := c.newVar(vi)
 	if err != nil {
 		return nil, err
 	}
+	defer C.dpiVar_release(v)
 
 	data := make([]*Data, sliceLen)
 	for i := 0; i < sliceLen; i++ {


### PR DESCRIPTION
After some investigation, I figured out that calling PL/SQL Stored Procedures may cause some memory leaks and SIGSEGV:

- Some objects (like pl/sql collections and attributes as complex types) don't need to call dpiObject_addRef; See https://github.com/oracle/odpi/issues/122

- Changed ObjectType.close() to avoid "signal SIGSEGV: segmentation violation"
