### PR TITLE
Add NewSubscriptionWithParams() method for extra params

### DIFF
--- a/orahlp.go
+++ b/orahlp.go
@@ -479,7 +479,7 @@ type Conn interface {
 	ClientVersion() (VersionInfo, error)
 	ServerVersion() (VersionInfo, error)
 	GetObjectType(name string) (ObjectType, error)
-	NewSubscriptionWithParams(SubscriptionParams, func(Event)) (*Subscription, error)
+	NewSubscriptionWithParams(SubscriptionParams) (*Subscription, error)
 	NewSubscription(string, func(Event)) (*Subscription, error)
 	Startup(StartupMode) error
 	Shutdown(ShutdownMode) error

--- a/orahlp.go
+++ b/orahlp.go
@@ -479,6 +479,7 @@ type Conn interface {
 	ClientVersion() (VersionInfo, error)
 	ServerVersion() (VersionInfo, error)
 	GetObjectType(name string) (ObjectType, error)
+	NewSubscriptionWithParams(SubscriptionParams, func(Event)) (*Subscription, error)
 	NewSubscription(string, func(Event)) (*Subscription, error)
 	Startup(StartupMode) error
 	Shutdown(ShutdownMode) error

--- a/subscr.go
+++ b/subscr.go
@@ -171,7 +171,9 @@ type SubscriptionParams struct {
 //
 // This code is EXPERIMENTAL yet!
 func (c *conn) NewSubscription(name string, cb func(Event)) (*Subscription, error) {
-	p := SubscriptionParams{name}
+	p := SubscriptionParams{
+		Name: name,
+	}
 	return c.NewSubscriptionWithParams(p, cb)
 }
 

--- a/subscr.go
+++ b/subscr.go
@@ -139,12 +139,48 @@ type Subscription struct {
 
 func (s *Subscription) getError() error { return s.conn.getError() }
 
+// SubscriptionParams are parameters for a new Subscription.
+type SubscriptionParams struct {
+
+	// The name of the subscription
+	Name string
+
+	// IP address on which the subscription listens to receive notifications,
+	// for a server-initiated connection.
+	//
+	// The IP address can be an IPv4 address in dotted decimal format such as 192.1.2.34
+	// or an IPv6 address in hexadecimal format such as 2001:0db8:0000:0000:0217:f2ff:fe4b:4ced.
+	//
+	// By default, an IP address will be selected by the Oracle client.
+	IPAddress	string
+
+	// Port number on which to receive notifications, for a server-initiated connection.
+	// The default value of 0 means that a port number will be selected by the Oracle client.
+	Port uint32
+
+	// Specifies whether a client or a server initiated connection should be created.
+	//
+	// This feature is only available when Oracle Client 19.4
+	// and Oracle Database 19.4 or higher are being used.
+	ClientInitiated bool
+}
+
 // NewSubscription creates a new Subscription in the DB.
 //
 // Make sure your user has CHANGE NOTIFICATION privilege!
 //
 // This code is EXPERIMENTAL yet!
 func (c *conn) NewSubscription(name string, cb func(Event)) (*Subscription, error) {
+	p := SubscriptionParams{name}
+	return c.NewSubscriptionWithParams(p, cb)
+}
+
+// NewSubscriptionWithParams creates a new DB Subscription with the given SubscriptionParams.
+//
+// Make sure your user has CHANGE NOTIFICATION privilege!
+//
+// This code is EXPERIMENTAL yet!
+func (c *conn) NewSubscriptionWithParams(p SubscriptionParams, cb func(Event)) (*Subscription, error) {
 	if !c.connParams.EnableEvents {
 		return nil, errors.New("subscription must be allowed by specifying \"enableEvents=1\" in the connection parameters")
 	}
@@ -156,9 +192,19 @@ func (c *conn) NewSubscription(name string, cb func(Event)) (*Subscription, erro
 	params.protocol = C.DPI_SUBSCR_PROTO_CALLBACK
 	params.qos = C.DPI_SUBSCR_QOS_BEST_EFFORT | C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
 	params.operations = C.DPI_OPCODE_ALL_OPS
-	if name != "" {
-		params.name = C.CString(name)
-		params.nameLength = C.uint32_t(len(name))
+	if p.Name != "" {
+		params.name = C.CString(p.Name)
+		params.nameLength = C.uint32_t(len(p.Name))
+	}
+	if p.IPAddress != "" {
+		params.ipAddress = C.CString(p.IPAddress)
+		params.ipAddressLength = C.uint32_t(len(p.IPAddress))
+	}
+	if p.Port != 0 {
+		params.portNumber = C.uint32_t(p.Port)
+	}
+	if p.ClientInitiated {
+		params.clientInitiated = C.int(1)
 	}
 	// typedef void (*dpiSubscrCallback)(void* context, dpiSubscrMessage *message);
 	params.callback = C.dpiSubscrCallback(C.CallbackSubscrDebug)


### PR DESCRIPTION
This PR addresses https://github.com/godror/godror/issues/22, by adding `NewSubscriptionWithParams()` method. It accepts a new `SubscriptionParams` struct that provides `ipAddress`, `portNumber` and `clientInitiated` options for `dpiSubscrCreateParams`.

This struct can also be expanded in the future to include even more subscription options.
