### PR TITLE
Add username and password to context before the connection attempt

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -948,7 +948,13 @@ func (d *drv) OpenConnector(name string) (driver.Connector, error) {
 //
 // The returned connection is only used by one goroutine at a
 // time.
-func (c connector) Connect(context.Context) (driver.Conn, error) {
+func (c connector) Connect(ctx context.Context) (driver.Conn, error) {
+	if key := ctx.Value(userpwCtxKey); key != nil {
+		userpw := key.([3]string)
+		c.ConnectionParams.Username = userpw[0]
+		c.ConnectionParams.Password = userpw[1]
+		c.ConnClass = userpw[2]
+	}
 	conn, err := c.drv.openConn(c.ConnectionParams)
 	if err != nil || c.onInit == nil || !conn.newSession {
 		return conn, err


### PR DESCRIPTION
A (too simple?) fix for #28 . Not sure if the mutation of `ConnectionParams` at the connection level has any unwanted side effects.