### PR TITLE
Require ODPI-C directories to be included in vendored go modules

### DIFF
--- a/odpi/embed/require.go
+++ b/odpi/embed/require.go
@@ -1,0 +1,8 @@
+// Copyright 2020 The Godror Authors
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+// +build require
+
+// Package embed contains required external dependencies from ODPI-C
+package embed

--- a/odpi/include/require.go
+++ b/odpi/include/require.go
@@ -1,0 +1,8 @@
+// Copyright 2020 The Godror Authors
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+// +build require
+
+// Package include contains required external dependencies from ODPI-C
+package include

--- a/odpi/src/require.go
+++ b/odpi/src/require.go
@@ -1,0 +1,8 @@
+// Copyright 2020 The Godror Authors
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+// +build require
+
+// Package src contains required external dependencies from ODPI-C
+package src

--- a/require.go
+++ b/require.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Godror Authors
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+// +build require
+
+package godror
+
+import (
+	_ "github.com/godror/godror/odpi/embed" // ODPI-C
+	_ "github.com/godror/godror/odpi/include" // ODPI-C
+	_ "github.com/godror/godror/odpi/src" // ODPI-C
+)


### PR DESCRIPTION
Gets the ODPI-C directories to be included in vendored golang modules (ie: `go mod vendor`).

Solves: https://github.com/godror/godror/issues/37

There is precedent to use build tags like this, see here: https://github.com/golang/go/issues/25922

I have confirmed this works in production.

Let me know if you need help or anything else to get this merged. I think a lot of people will appreciate this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/godror/godror/38)
<!-- Reviewable:end -->
