### PR TITLE
Ability to override client timezone by adding it to connection string

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -187,7 +187,7 @@ func (d *drv) openConn(P ConnectionParams) (*conn, error) {
 	}
 
 	P.Comb()
-	c := &conn{drv: d, connParams: P, timeZone: time.Local, Client: d.clientVersion}
+	c := &conn{drv: d, connParams: P, timeZone: P.Timezone, Client: d.clientVersion}
 	connString := P.String()
 
 	if Log != nil {
@@ -301,7 +301,7 @@ func (d *drv) openConn(P ConnectionParams) (*conn, error) {
 		return nil, errors.Errorf("params=%s extAuth=%v: %w", P.String(), extAuth, d.getError())
 	}
 	C.dpiPool_setStmtCacheSize(dp, 40)
-	pool := &connPool{dpiPool: dp}
+	pool := &connPool{dpiPool: dp, timeZone: P.Timezone}
 	d.mu.Lock()
 	d.pools[connString] = pool
 	d.mu.Unlock()
@@ -674,6 +674,8 @@ func ParseConnString(connString string) (ConnectionParams, error) {
 		} else {
 			return P, errors.Errorf("%s: %w", tz, err)
 		}
+	} else {
+		P.Timezone = time.Local
 	}
 
 	for _, task := range []struct {


### PR DESCRIPTION
The timezone specified in the connection string is parsed and stored to connection-params, but never actually used - timezone/offset of connection are always overriden by dbtimezone/systimestamp' s offset combination.
This pull request makes connection string's timezone to be actually usable.