### PR TITLE
Use default close mode

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -180,7 +180,7 @@ func (c *conn) close(doNotReuse bool) error {
 			C.dpiConn_breakExecution(dpiConn)
 		}
 	}()
-	C.dpiConn_close(dpiConn, C.DPI_MODE_CONN_CLOSE_DROP, nil, 0)
+	C.dpiConn_close(dpiConn, C.DPI_MODE_CONN_CLOSE_DEFAULT, nil, 0)
 	close(done)
 	return nil
 }


### PR DESCRIPTION
The mode currently being used (DPI_MODE_CONN_CLOSE_DROP) forcibly drops the session from the sesion pool. This diminishes performance as the next time a session is required from the pool it has to be built again. This is particularly important when you are using the session pool internally by setting the parameter `StandaloneConnection` to false and setting `db.SetMaxIdleConns(0)` to disable the Go pooling capability.