### PR TITLE
Fix memory leak

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Ricardo Vegas <rvegas@users.noreply.github.com>
 Robin van Duiven <robin@aqua-it.com>
 Ryan Bastic <ryan@gooddoglabs.com>
 Saimon <semyuon@gmail.com>
+Sudarshan Soma <sudarshan.ss.s@oracle.com>
 Tamás Gulácsi <T.Gulacsi@unosoft.hu>
 Tomoya AMACHI <tomoya.amachi@gmail.com>
 ubinix-warun <warun@ubinix.com>

--- a/drv.go
+++ b/drv.go
@@ -293,7 +293,7 @@ func (d *drv) acquireConn(pool *connPool, P commonAndConnParams) (*C.dpiConn, bo
 
 	// assign connection class
 	if P.ConnClass != "" {
-		cConnClass := C.CString(P.ConnClass)
+		cConnClass = C.CString(P.ConnClass)
 		connCreateParams.connectionClass = cConnClass
 		connCreateParams.connectionClassLength = C.uint32_t(len(P.ConnClass))
 	}


### PR DESCRIPTION
A sample GO application with single goroutine is tried with Connection acquire and release in a continous loop.

Tried with 1 million iterations, RSS of process keeps increasing and doesnt reduce even after goroutine completes all iterations and exits.

pseudo code

i <- 1, 1000000

conn, err := db.Conn(ctx)

   if err != nil {                                                       
      log.Fatal(err)                                                      
    }                                                                     
conn.Close()

After checking the connection acquire/release code walk through, found the following variable, Connclass was not freed.

cConnClass is allocated in C heap using CString but C.Free is missed. it happens since colon (:) in line creates new variable and shadows the earlier declared variable with same name.

cConnClass := C.CString(P.ConnClass)

Tests done:

without fix:
connection acquire/release for 1 million , RSS is 74204 MB

with fix:
connection acquire/release for 1 million , RSS is 36552 MB