### PR TITLE
Make defaultconnectionclass as empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ with OUT parameters, or sending/retrieving PL/SQL array types - just give a
 
 The array size of the returned PL/SQL arrays can be set with `godror.ArraySize(2000)` (default value is 1024).
 
-Connections are pooled by default (except `AS SYSOPER` or `AS SYSDBA`).
-
 ## Speed
 
 Correctness and simplicity is more important than speed, but the underlying ODPI-C library

--- a/conn_test.go
+++ b/conn_test.go
@@ -96,14 +96,14 @@ func TestParseConnString(t *testing.T) {
 		Want ConnectionParams
 	}{
 		"simple": {In: "user/pass@sid", Want: wantDefault},
-		"full": {In: "oracle://user:pass@sid/?poolMinSessions=3&poolMaxSessions=9&poolIncrement=3&connectionClass=POOLED&standaloneConnection=0&sysoper=1&sysdba=0&poolWaitTimeout=200ms&poolSessionMaxLifetime=4000s&poolSessionTimeout=2000s",
+		"full": {In: "oracle://user:pass@sid/?poolMinSessions=3&poolMaxSessions=9&poolIncrement=3&connectionClass=TestClassName&standaloneConnection=0&sysoper=1&sysdba=0&poolWaitTimeout=200ms&poolSessionMaxLifetime=4000s&poolSessionTimeout=2000s",
 			Want: ConnectionParams{
 				CommonParams: CommonParams{
 					Username: "user", Password: "pass", DSN: "sid",
 					Timezone: time.Local,
 				},
 				ConnParams: ConnParams{
-					ConnClass: "POOLED", IsSysOper: true,
+					ConnClass: "TestClassName", IsSysOper: true,
 				},
 				PoolParams: PoolParams{
 					MinSessions: 3, MaxSessions: 9, SessionIncrement: 3,
@@ -138,14 +138,14 @@ func TestParseConnString(t *testing.T) {
 			},
 		},
 
-		"onInit": {In: "oracle://user:pass@sid/?poolMinSessions=3&poolMaxSessions=9&poolIncrement=3&connectionClass=POOLED&standaloneConnection=0&sysoper=1&sysdba=0&poolWaitTimeout=200ms&poolSessionMaxLifetime=4000s&poolSessionTimeout=2000s&onInit=a&onInit=b",
+		"onInit": {In: "oracle://user:pass@sid/?poolMinSessions=3&poolMaxSessions=9&poolIncrement=3&connectionClass=TestClassName&standaloneConnection=0&sysoper=1&sysdba=0&poolWaitTimeout=200ms&poolSessionMaxLifetime=4000s&poolSessionTimeout=2000s&onInit=a&onInit=b",
 			Want: ConnectionParams{
 				CommonParams: CommonParams{
 					Username: "user", Password: "pass", DSN: "sid",
 					Timezone: time.Local,
 				},
 				ConnParams: ConnParams{
-					ConnClass: "POOLED", IsSysOper: true,
+					ConnClass: "TestClassName", IsSysOper: true,
 				},
 				PoolParams: PoolParams{
 					MinSessions: 3, MaxSessions: 9, SessionIncrement: 3,

--- a/drv.go
+++ b/drv.go
@@ -17,7 +17,7 @@
 //     poolMinSessions=1& \
 //     poolMaxSessions=1000& \
 //     poolIncrement=1& \
-//     connectionClass=POOLED& \
+//     connectionClass=MyClassName& \
 //     standaloneConnection=1& \
 //     enableEvents=0& \
 //     heterogeneousPool=0& \
@@ -38,7 +38,10 @@
 // without the connectionClass, but will specify it on each session acquire.
 // Thus you can cluster the session pool with classes, or use POOLED for DRCP.
 //
-// For what can be used as "sid", see https://docs.oracle.com/en/database/oracle/oracle-database/19/netag/configuring-naming-methods.html#GUID-E5358DEA-D619-4B7B-A799-3D2F802500F1
+// For connectionClass usage, see https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-CE6E4DCC-92DF-4946-92B8-2BDD9845DA35
+//
+// If you specify server_type as POOLED in sid, DRCP is used.
+// For what can be used as "sid", see https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-E5358DEA-D619-4B7B-A799-3D2F802500F1
 package godror
 
 /*
@@ -101,8 +104,8 @@ const (
 	DefaultSessionIncrement = 1
 	// DefaultPoolIncrement is a deprecated name for DefaultSessionIncrement.
 	DefaultPoolIncrement = DefaultSessionIncrement
-	// DefaultConnectionClass is the default connectionClass
-	DefaultConnectionClass = "GODROR"
+	// DefaultConnectionClass is empty, which allows to use the poolMinSessions created as part of session pool creation for non-DRCP. For DRCP, connectionClass needs to be explicitly mentioned.
+	DefaultConnectionClass = ""
 	// NoConnectionPoolingConnectionClass is a special connection class name to indicate no connection pooling.
 	// It is the same as setting standaloneConnection=1
 	NoConnectionPoolingConnectionClass = "NO-CONNECTION-POOLING"
@@ -812,9 +815,6 @@ func ParseConnString(connString string) (ConnectionParams, error) {
 			P.Password, P.DSN = connString[:i], connString[i+1:]
 		} else {
 			P.Password = connString
-		}
-		if strings.HasSuffix(P.DSN, ":POOLED") {
-			P.ConnClass, P.DSN = "POOLED", P.DSN[:len(P.DSN)-7]
 		}
 		P.comb()
 		if Log != nil {

--- a/z_test.go
+++ b/z_test.go
@@ -139,7 +139,7 @@ func init() {
 			EnableEvents: true,
 		},
 		ConnParams: godror.ConnParams{
-			ConnClass:   "POOLED",
+			ConnClass:   "TestClassName",
 			ShardingKey: []interface{}{"gold", []byte("silver"), int(42)},
 		},
 		PoolParams: godror.PoolParams{
@@ -1949,7 +1949,7 @@ func TestNoConnectionPooling(t *testing.T) {
 	t.Parallel()
 	db, err := sql.Open("godror",
 		strings.Replace(
-			strings.Replace(testConStr, "POOLED", godror.NoConnectionPoolingConnectionClass, 1),
+			strings.Replace(testConStr, "TestClassName", godror.NoConnectionPoolingConnectionClass, 1),
 			"standaloneConnection=0", "standaloneConnection=1", 1,
 		),
 	)


### PR DESCRIPTION
#### code changes done
- connections are now not pooled by default, corrected Readme
- Default connectionClass variable, DefaultConnectionClass is made empty.
- https link for refering the sid details is made relative (always refer to latest doc)
- removed Doc changes which indicate "connectionClass as POOLED requests for DRCP" , which is not the case but user has to mention :POOLED in connect string as mentioned in sid naming conventions doc,
https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-E5358DEA-D619-4B7B-A799-3D2F802500F1

#### connectionClass behaviour
- If connectionClass default is non empty and user has configured the PoolMinSessions, the pre-created PoolMin sessions can’t be used in subsequent DB queries (db.ExecContext, db.Query, ..), instead a new connection is created . The reason is : when DB query, OCISessionGet provides a non empty classname like GODROR, it wont match with default class name that is associated with session pool pre-created connections. Hence it tries to create new connections on DB query, OCISessionGet. If we pass empty connectionclass, OCISessionGet appends the same class name that it created pre-connections with and hence one of the PoolMinSessions is served .

- With Default connectionClass as empty, applications can take advantage of pre-created sessions mentioned in PoolMinsessions for subsequent DB queries.

- If user wants to mention connectionClass, they can pass PoolMinSessions as 0, so that the subsequent DB queries will result in session pool clustered as per that connectionClass name.

### Note for DRCP
- poolMinsessions, poolIncrement are treated as always 1.
- connection class has to be explicitly mentioned in the application. Currently with non-empty default connectionClass, 2 GO client applications that ideally should not share for security reasons end up sharing connections from DRCP pool.
- With empty Default connectionClass, the two GO client applications shall not share connections from DRCP unless applications explicitly specify the same connection class while requesting the connections.
- By setting connectionClass explicitly from GO applications, the sharing of pre-existing session's will be done based on matching the connectionClass provided from applications with the pre-existing sessions. If they don't match, pre-existing sessions cant be shared.

#### Testing:
1. pass connect string with connectionClass as non empty, TestMyClass . Verify the minsessions created were not getting used from GetPoolStats output, instead new connections(open count) are created. go application just does a simple DB query.
```
connString := fmt.Sprintf("oracle://%s:%s@%s/%s?connectionClass=TestMyClass&standaloneConnection=0&poolMinSessions=5&poolMaxSessions=50&poolIncrement=1&poolGetMode=PoolNoWait", "scott", "tiger", "ip:1521", "us.oracle.com")
stats: busy=1 open=6 max=50 maxLifetime=1h0m0s timeout=5m0s waitTimeout=30s
```
open=6, indicates new connections are created apart from 5 pre-created ones. 
If we remove connectionClass=TestMyClass and run it, stats do indicate that subsequent DB query uses one of the 5 connections that were pre-created as part of poolMinSessions.
stats
```
busy=1 open=5 max=50 maxLifetime=1h0m0s timeout=5m0s waitTimeout=30s
```
2. Keep  poolMinSessions equal to max sessions that would be required by program at any point of time. This avoids expanding session pool at runtime and hence no waiting time for sessions to get created. 
application had 5 go routines, hence kept pool min, max as 5.

```
oracle://scott:tiger@ip:1521/us.oracle.com?standaloneConnection=0&poolMinSessions=5&poolMaxSessions=5&poolSessionTimeout=300s&poolWaitTimeout=300000&poolIncrement=1
```
all 5 go routines complete executing the DB query, select.

3. DRCP test case :
Request for drcp by specifying :POOLED in connectstring.
```
connString := fmt.Sprintf("oracle://%s:%s@%s/%s:POOLED?standaloneConnection=0&poolMinSessions=0&poolMaxSessions=1&poolIncrement=1&poolWaitTimeout=0", "scott", "tiger", "ip:1521", "us.oracle.com")
```
GO application runs 1000 iterations , each iteration runs a select sql statement.

sql script, a.sql used to read stats 
```
select value,name from v$sysstat where name like '%roundtrips to/from cl%' or name like '%parse count%';
select num_authentications,num_requests,num_hits,num_misses from v$cpool_stats;
```

- case1: different select sql run on each iteration, select %d from dual, itr
verified on server:

Number of authentications (1) , parse count (around number of iterations 1000) , NUM_MISSES (1) , NUM_Requests(1000), NUM_HITS(999) .

- case 2: Same sql , select 0 from dual, itr  by multiple iterations 
verified on server:

Number of authentications (1) , parse count (verfy less because of result caching) , NUM_MISSES (1), NUM_HITS(999), NUM_REQS(1000)

4. DRCP connection class tests:
GO pgm :
Case1 : It sets connectionclass explicitly in connectstring.(same as driver setting “GODROR” as default ConnectionClass string)
```
Connstring := fmt.Sprintf("oracle://%s:%s@%s/%s:POOLED?standaloneConnection=0&connectionClass=MyTestClass&poolMinSessions=1&poolMaxSessions=1&poolIncrement=1&poolWaitTimeout=0", "scott", "tiger", "ip:1521", "oracle.com")
```
After running this program first time, NUM_MISSES count is increased. Running it second, third, … NUM_HITS count is increased.

```
SQL> SELECT connection_pool, status, minsize, maxsize, incrsize FROM dba_cpool_info;
 
CONNECTION_POOL
--------------------------------------------------------------------------------
STATUS                    MINSIZE    MAXSIZE    INCRSIZE
---------------- ---------- ---------- ----------
SYS_DEFAULT_CONNECTION_POOL
ACTIVE                                   4               40                       2
 
```
First time:
 
```
SQL> @a.sql;
 
     VALUE NAME
---------- ----------------------------------------------------------------
     12163 parse count (total)
      2121 parse count (hard)
                5 parse count (failures)
                14 parse count (describe)
       221 SQL*Net roundtrips to/from client
 
 
NUM_AUTHENTICATIONS NUM_REQUESTS   NUM_HITS NUM_MISSES
------------------- ------------ ---------- ----------
                                1                  1        0                1

``` 
Secondtime:

```
@a.sql;

 VALUE NAME
 12177 parse count (total)
  2121 parse count (hard)
            5 parse count (failures)
            14 parse count (describe)
   233 SQL*Net roundtrips to/from client
NUM_AUTHENTICATIONS NUM_REQUESTS NUM_HITS NUM_MISSES

                              2                  2        1                1
```
ThirdTime:

```
SQL> @a.sql;

 VALUE NAME
 12267 parse count (total)
  2128 parse count (hard)
            5 parse count (failures)
            14 parse count (describe)
   249 SQL*Net roundtrips to/from client
NUM_AUTHENTICATIONS NUM_REQUESTS NUM_HITS NUM_MISSES

                              3                  3        2                1
```
   - Case 2, Without setting connclass:
NUM_MISSES increase , NUM_HITS are not increased.
 
First time:
```
@a.sql;
 
     VALUE NAME
---------- ----------------------------------------------------------------
     12336 parse count (total)
      2130 parse count (hard)
                5 parse count (failures)
                14 parse count (describe)
       267 SQL*Net roundtrips to/from client
 
 
NUM_AUTHENTICATIONS NUM_REQUESTS   NUM_HITS NUM_MISSES
------------------- ------------ ---------- ----------
                                  1                  1        0                1
 
```
Second time:

```
@a.sql;
 
     VALUE NAME
---------- ----------------------------------------------------------------
     12353 parse count (total)
      2130 parse count (hard)
                5 parse count (failures)
                14 parse count (describe)
       275 SQL*Net roundtrips to/from client
 
 
NUM_AUTHENTICATIONS NUM_REQUESTS   NUM_HITS NUM_MISSES
------------------- ------------ ---------- ----------
                                  2                  2        0                2
 
```
 

5. GO Test suite with :POOLED (DRCP):
export GODROR_TEST_DB=10.248.121.76:1521/nlyview.regress.rdbms.dev.us.oracle.com:POOLED
 
```
go test  -run TestCancel
export GODROR_TEST_USERNAME=scott
export GODROR_TEST_PASSWORD=tiger
export GODROR_TEST_DB=ip:1521/us.oracle.com:POOLED
export GODROR_TEST_STANDALONE=0
oracle://scott:SECRET-4NMAKZqXbbo=@ip:1521/us.oracle.com:POOLED?connectionClass=TestClassName&enableEvents=1&heterogeneousPool=0&poolIncrement=2&poolMaxSessions=16&poolMinSessions=2&poolSessionMaxLifetime=5m0s&poolSessionTimeout=1m0s&poolWaitTimeout=5s&prelim=0&standaloneConnection=0&sysasm=0&sysdba=0&sysoper=0&timezone=local
Client: 21.1.0.0.0 Timezone: PST8PDT
Server: 21.1.0.0.0 [Oracle Database 21c Enterprise Edition Release 21.0.0.0.0 - Development; Version 21.1.0.0.0] Timezone: PST8PDT
PASS
ok           github.com/godror/godror          0.109s
 
``` 
```
bash-4.2$
go test -v . | grep PASS:
--- PASS: TestMaybeBadConn (0.00s)
--- PASS: TestCalculateTZ (0.00s)
--- PASS: TestParseTZ (0.00s)
--- PASS: TestDataSetGet (0.00s)
--- PASS: TestFromErrorInfo (0.00s)
--- PASS: TestMarshalJSON (0.00s)
--- PASS: TestMapToSlice (0.00s)
--- PASS: TestConnCut (1.25s)
--- PASS: TestContextWithUserPassw (0.07s)
--- PASS: TestPlSqlObjectDirect (1.26s)
--- PASS: TestOpenBadMemory (0.06s)
--- PASS: TestRanaOraIssue244 (0.81s)
--- PASS: TestExecHang (1.18s)
--- PASS: TestMaxOpenCursors (2.50s)
--- PASS: TestSDO (0.38s)
--- PASS: TestIssue134 (1.64s)
--- PASS: TestObject (0.20s)
--- PASS: TestOnInit (0.08s)
--- PASS: TestSelectTypes (4.17s)
--- PASS: TestResetSession (0.06s)
--- PASS: TestOpenCloseLob (0.13s)
--- PASS: TestOpenCloseLob/0 (0.09s)
--- PASS: TestOpenCloseLob/1 (0.00s)
--- PASS: TestOpenCloseLob/2 (0.00s)
--- PASS: TestOpenCloseLob/3 (0.00s)
--- PASS: TestOpenCloseLob/4 (0.00s)
--- PASS: TestOpenCloseLob/5 (0.00s)
--- PASS: TestOpenCloseLob/6 (0.00s)
--- PASS: TestOpenCloseLob/7 (0.00s)
--- PASS: TestOpenCloseLob/8 (0.00s)
--- PASS: TestOpenCloseLob/9 (0.00s)
--- PASS: TestOpenCloseLob/10 (0.00s)
--- PASS: TestOpenCloseLob/11 (0.00s)
--- PASS: TestOpenCloseLob/12 (0.00s)
--- PASS: TestOpenCloseLob/13 (0.00s)
--- PASS: TestOpenCloseLob/14 (0.00s)
--- PASS: TestOpenCloseLob/15 (0.00s)
--- PASS: TestOpenCloseLob/16 (0.00s)
--- PASS: TestOpenCloseLob/17 (0.00s)
--- PASS: TestOpenCloseLob/18 (0.00s)
--- PASS: TestOpenCloseLob/19 (0.00s)
--- PASS: TestParseConnString (0.00s)
--- PASS: TestParseConnString/full (0.00s)
--- PASS: TestParseConnString/@ (0.00s)
--- PASS: TestParseConnString/xo (0.00s)
--- PASS: TestParseConnString/heterogeneous (0.00s)
--- PASS: TestParseConnString/ipv6 (0.00s)
--- PASS: TestParseConnString/onInit (0.00s)
--- PASS: TestParseConnString/simple (0.00s)
--- PASS: TestNumberBool (0.01s)
--- PASS: TestSelectNullTime (0.00s)
--- PASS: TestPtrArg (0.18s)
--- PASS: TestQueryTimeout (0.19s)
--- PASS: TestNoConnectionPooling (0.00s)
--- PASS: TestBool (0.21s)
--- PASS: TestNullIntoNum (0.05s)
--- PASS: TestRO (0.02s)
--- PASS: TestExecTimeout (0.12s)
--- PASS: TestReturning (0.06s)
--- PASS: TestNullFloat (0.04s)
--- PASS: TestColumnSize (0.14s)
--- PASS: TestNumberMarshal (0.00s)
--- PASS: TestNumberNull (0.05s)
--- PASS: TestInsertIntervalDS (0.07s)
--- PASS: TestNumInputs (0.01s)
--- PASS: TestSelectFloat (0.15s)
--- PASS: TestInputArray (0.45s)
--- PASS: TestReadWriteLob (0.39s)
--- PASS: TestExecuteMany (0.49s)
--- PASS: TestSelectRefCursorWrap (0.38s)
--- PASS: TestSelectRefCursor (0.05s)
--- PASS: TestOutParam (0.13s)
--- PASS: TestInOutArray (0.18s)
--- PASS: TestInOutArray/inout_vc (0.00s)
--- PASS: TestInOutArray/inout_num (0.00s)
--- PASS: TestInOutArray/inout_dt (0.00s)
--- PASS: TestInOutArray/inout_vc-1 (0.00s)
--- PASS: TestInOutArray/inout_vc-0 (0.00s)
--- PASS: TestInOutArray/p2 (0.00s)
--- PASS: TestFuncBool (0.05s)
--- PASS: TestParseOnly (0.16s)
--- PASS: TestExecRefCursor (1.40s)
--- PASS: TestDescribeQuery (0.25s)
--- PASS: TestPlSqlObject (0.10s)
--- PASS: TestORA1000 (2.76s)
--- PASS: TestCallWithObject (0.31s)
--- PASS: TestLOBAppend (0.03s)
--- PASS: TestImplicitResults (0.09s)
--- PASS: TestGetDBTimeZone (0.01s)
--- PASS: TestExecInt64 (0.05s)
--- PASS: TestSelectObjectTable (0.40s)
--- PASS: TestSelectCustomType (0.28s)
--- PASS: TestSelectOrder (0.26s)
--- PASS: TestPing (60.05s)


###Note: 
TestDbmsOutput and TestPLSQLTypes are failing due to setup issues, hence not captured.