### PR TITLE
Add a directory README for GitHub browsers

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,4 @@
+# Go DRiver for ORacle Documentation
+
+This `godror/doc` directory contains the user guide source files.
+Visit https://godror.github.io/godror/doc/contents.html to view the User Guide.  The API Documentation is at https://pkg.go.dev/github.com/godror/godror?tab=doc.


### PR DESCRIPTION
This may help anyone clicking down to the directory on GitHub,

@tgulacsi what's the plan for syncing the doc files to the gh-pages branch, which is now behind.  Do you want a PR or will you just do a simple manual copy as part of your release process?