### PR TITLE
Show godror's version in the test log

### DIFF
--- a/z_test.go
+++ b/z_test.go
@@ -180,6 +180,7 @@ func init() {
 	}
 
 	fmt.Println("#", P.String())
+	fmt.Println("Version:", godror.Version)
 	ctx, cancel := context.WithTimeout(testContext("init"), 30*time.Second)
 	defer cancel()
 	if err = godror.Raw(ctx, testDb, func(cx godror.Conn) error {


### PR DESCRIPTION
This can be useful when comparing tests from different releases.  It may be useful to confirm what versions users are running when they report issues.