### PR TITLE
Update issue template to adjust info bullet formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -35,7 +35,7 @@ e.g. 4.8.3
 
 **Machine (please complete the following information):**
  - OS: [e.g. win]
- - Architecture [e.g. x86_64]
+ - Architecture: [e.g. x86_64]
  - Version: [e.g. 10]
 
 **Additional context**


### PR DESCRIPTION
Add missing colon to Architecture info bullet item. I spotted this while submitting an issue earlier using the template.