### PR TITLE
adds a reference to the object type Collections

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -543,6 +543,9 @@ func (t *ObjectType) init() error {
 			t.CollectionOf.Schema = t.Schema
 			t.CollectionOf.Name = t.Name
 		}
+		if t.CollectionOf.dpiObjectType != nil {
+			C.dpiObjectType_addRef(t.CollectionOf.dpiObjectType)
+		}
 	}
 	if numAttributes == 0 {
 		t.Attributes = map[string]ObjectAttribute{}


### PR DESCRIPTION
Adds a reference to object type to avoid SIGABRT like:

```
free(): corrupted unsorted chunks
SIGABRT: abort
PC=0x7fcc67d88c81 m=11 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: unknown pc 0x7fcc67d88c81
stack: frame={sp:0x7fcc22ffc9f0, fp:0x0} stack=[0x7fcc227fd288,0x7fcc22ffce88)
00007fcc22ffc8f0:  0000000000000000  0000000000000000 
00007fcc22ffc900:  0000000000000000  0000000000000000 
00007fcc22ffc910:  00007fcc22ffc990  00007fcc187033c5 
00007fcc22ffc920:  00007fcc340ae658  0000000000000000 
00007fcc22ffc930:  00007fcc340c0d00  0000000000000001 
00007fcc22ffc940:  00007fcc34145630  00007fcc22ffc9e0 
00007fcc22ffc950:  00000000000000fb  00007fcc22ffc9e0 
00007fcc22ffc960:  0000000000000000  0000000000000001 
00007fcc22ffc970:  0000000000000000  0000000000000000 
00007fcc22ffc980:  00007fcc340ae658  00007fcc22ffcaa8 
00007fcc22ffc990:  00007fcc22ffca40  00007fcc1887239f 
00007fcc22ffc9a0:  0000000000000001  00007fcc34145630 
00007fcc22ffc9b0:  00007fcc340ae658  0000000000000000 
00007fcc22ffc9c0:  00007fcc22ffca10  00007fcc18867adf 
00007fcc22ffc9d0:  00007fcc34159678  00007fcc34161a38 
00007fcc22ffc9e0:  00007fcc34161a40  00007fcc1b41a35c 
00007fcc22ffc9f0: <0000000000000000  00007fcc340ae658 
00007fcc22ffca00:  0000000000000000  00007fcc34103828 
00007fcc22ffca10:  00007fcc22ffca60  00007fcc188679ed 
00007fcc22ffca20:  00007fcc34145630  00007fcc340ae658 
00007fcc22ffca30:  00007fcc22ffcb00  00007fcc1b41a35c 
00007fcc22ffca40:  00007fcc34145630  00007fcc340ae658 
00007fcc22ffca50:  00007fcc22ffcb00  0000000000000000 
00007fcc22ffca60:  00007fcc22ffcae0  00007fcc188726a0 
00007fcc22ffca70:  fffffffe7fffffff  ffffffffffffffff 
00007fcc22ffca80:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffca90:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcaa0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcab0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcac0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcad0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcae0:  ffffffffffffffff  ffffffffffffffff 
runtime: unknown pc 0x7fcc67d88c81
stack: frame={sp:0x7fcc22ffc9f0, fp:0x0} stack=[0x7fcc227fd288,0x7fcc22ffce88)
00007fcc22ffc8f0:  0000000000000000  0000000000000000 
00007fcc22ffc900:  0000000000000000  0000000000000000 
00007fcc22ffc910:  00007fcc22ffc990  00007fcc187033c5 
00007fcc22ffc920:  00007fcc340ae658  0000000000000000 
00007fcc22ffc930:  00007fcc340c0d00  0000000000000001 
00007fcc22ffc940:  00007fcc34145630  00007fcc22ffc9e0 
00007fcc22ffc950:  00000000000000fb  00007fcc22ffc9e0 
00007fcc22ffc960:  0000000000000000  0000000000000001 
00007fcc22ffc970:  0000000000000000  0000000000000000 
00007fcc22ffc980:  00007fcc340ae658  00007fcc22ffcaa8 
00007fcc22ffc990:  00007fcc22ffca40  00007fcc1887239f 
00007fcc22ffc9a0:  0000000000000001  00007fcc34145630 
00007fcc22ffc9b0:  00007fcc340ae658  0000000000000000 
00007fcc22ffc9c0:  00007fcc22ffca10  00007fcc18867adf 
00007fcc22ffc9d0:  00007fcc34159678  00007fcc34161a38 
00007fcc22ffc9e0:  00007fcc34161a40  00007fcc1b41a35c 
00007fcc22ffc9f0: <0000000000000000  00007fcc340ae658 
00007fcc22ffca00:  0000000000000000  00007fcc34103828 
00007fcc22ffca10:  00007fcc22ffca60  00007fcc188679ed 
00007fcc22ffca20:  00007fcc34145630  00007fcc340ae658 
00007fcc22ffca30:  00007fcc22ffcb00  00007fcc1b41a35c 
00007fcc22ffca40:  00007fcc34145630  00007fcc340ae658 
00007fcc22ffca50:  00007fcc22ffcb00  0000000000000000 
00007fcc22ffca60:  00007fcc22ffcae0  00007fcc188726a0 
00007fcc22ffca70:  fffffffe7fffffff  ffffffffffffffff 
00007fcc22ffca80:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffca90:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcaa0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcab0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcac0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcad0:  ffffffffffffffff  ffffffffffffffff 
00007fcc22ffcae0:  ffffffffffffffff  ffffffffffffffff 

goroutine 438 [syscall]:
runtime.cgocall(0xb230b0, 0xc00064b198, 0x82)
        /usr/local/go/src/runtime/cgocall.go:133 +0x5b fp=0xc00064b168 sp=0xc00064b130 pc=0x4108cb
github.com/godror/godror._Cfunc_dpiObjectType_release(0x7fcc08048380, 0x7fcc00000000)
        _cgo_gotypes.go:3820 +0x49 fp=0xc00064b198 sp=0xc00064b168 pc=0x761fa9
github.com/godror/godror.(*ObjectType).Close.func1(0x7fcc08048380, 0xc00036e180)
        /home/walter/go/pkg/mod/github.com/godror/godror@v0.22.2/obj.go:494 +0x4d fp=0xc00064b1c8 sp=0xc00064b198 pc=0x79ff8d
github.com/godror/godror.(*ObjectType).Close(0xc000573580, 0x0, 0x0)
        /home/walter/go/pkg/mod/github.com/godror/godror@v0.22.2/obj.go:494 +0x40f fp=0xc00064b508 sp=0xc00064b1c8 pc=0x77cf8f
git.serpro/scc-acao-judicial/judi/internal/infrastructure/database.PrOrdenarPdcomp(0xe0cd80, 0xc00036e090, 0xdf8560, 0xc00036e0f0, 0xc0003aac20, 0x12, 0x1b6154, 0xbf1c01, 0xbcf4c0, 0xdf8860, ...)
```

This error occurs in a production system after some requests to a Stored Procedure that return a PL/SQL Collection. 