### PR TITLE
modify ContextWithUserPassw to retain values set in pool creation

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -855,8 +855,16 @@ func (tt TraceTag) String() string {
 	return q.Encode()
 }
 
-const paramsCtxKey = ctxKey("params")
+const paramsCtxKey              = ctxKey("params")
+const userPasswdConnClassCtxKey = ctxKey("userPasswdConnClass")
 
+// UserPasswdConnClassTag consists of Username, Password 
+// and ConnectionClass values that can be set with ContextWithUserPassw
+type UserPasswdConnClassTag struct {
+	Username string
+	Password string
+	ConnClass string
+}
 // ContextWithParams returns a context with the specified parameters. These parameters are used
 // to modify the session acquired from the pool.
 //
@@ -875,10 +883,7 @@ func ContextWithParams(ctx context.Context, commonParams dsn.CommonParams, connP
 //
 // Also, you should disable the Go connection pool with DB.SetMaxIdleConns(0).
 func ContextWithUserPassw(ctx context.Context, user, password, connClass string) context.Context {
-	return ContextWithParams(ctx,
-		dsn.CommonParams{Username: user, Password: dsn.NewPassword(password)},
-		dsn.ConnParams{ConnClass: connClass},
-	)
+    return context.WithValue(ctx, userPasswdConnClassCtxKey, UserPasswdConnClassTag{user, password, connClass})
 }
 
 // StartupMode for the database.

--- a/z_heterogeneous_test.go
+++ b/z_heterogeneous_test.go
@@ -29,7 +29,6 @@ func TestHeterogeneousPoolIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	cs.Heterogeneous = true
-	cs.EnableEvents = false
 	username := cs.Username
 	testHeterogeneousConStr := cs.StringWithPassword()
 	t.Log(testHeterogeneousConStr)


### PR DESCRIPTION
ContextWithUserPassw was setting the godror parameters such as Timezone, EnableEvents to default values. 
so if we do QueryRowContext with ctx derived from godror.ContextWithUserPassw , it would change the godror CommonParams, ConnParams which results in creating new pool as the poolKey changes.

Fixes are made to retain CommonParams, ConnParams of the connection and overwrite the username, password, connectionclass parameters passed .

Tests:

go test  -run TestContextWithUserPassw
go test  -run TestHeterogeneousPoolIntegration
