### PR TITLE
Add support for Proxy Support in external authentication

### DIFF
--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -241,6 +241,7 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	q.Add("standaloneConnection", B(P.StandaloneConnection))
 	q.Add("enableEvents", B(P.EnableEvents))
 	q.Add("heterogeneousPool", B(P.Heterogeneous))
+	q.Add("externalAuth", B(P.ExternalAuth))
 	q.Add("prelim", B(P.IsPrelim))
 	q.Add("poolWaitTimeout", P.WaitTimeout.String())
 	q.Add("poolSessionMaxLifetime", P.MaxLifeTime.String())
@@ -375,6 +376,7 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 
 		{&P.EnableEvents, "enableEvents"},
 		{&P.Heterogeneous, "heterogeneousPool"},
+		{&P.ExternalAuth, "externalAuth"},
 		{&P.StandaloneConnection, "standaloneConnection"},
 	} {
 		s := q.Get(task.Key)

--- a/z_heterogeneous_test.go
+++ b/z_heterogeneous_test.go
@@ -16,6 +16,19 @@ import (
 	godror "github.com/godror/godror"
 )
 
+// Following are covered
+// - standalone=0
+//   - heterogeneous pool create with username, password and Query
+//     without username, password
+//   - Query from pool with session-username (proxyUser) ,
+//     session-password(proxyPassword)
+//   - Query from pool with session-username (proxyUser) and without
+//     session-password
+//   - Query from pool with session-username (proxyUser) enclosed
+//     under brackets for failure test
+// - standalone=1
+//   - create connection with username, password
+
 func TestHeterogeneousPoolIntegration(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(testContext("HeterogeneousPoolIntegration"), 30*time.Second)
@@ -28,7 +41,9 @@ func TestHeterogeneousPoolIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs.Heterogeneous = true
+	if !cs.IsStandalone() {
+		cs.Heterogeneous = true
+	}
 	username := cs.Username
 	testHeterogeneousConStr := cs.StringWithPassword()
 	t.Log(testHeterogeneousConStr)
@@ -70,26 +85,93 @@ func TestHeterogeneousPoolIntegration(t *testing.T) {
 		In   context.Context
 		Want string
 	}{
-		"noContext":       {In: ctx, Want: username},
-		"proxyUser":       {In: godror.ContextWithUserPassw(ctx, proxyUser, proxyPassword, ""), Want: proxyUser},
-		"proxyUserNoPass": {In: godror.ContextWithUserPassw(ctx, proxyUser, "", ""), Want: proxyUser},
+		"noContext":             {In: ctx, Want: username},
+		"proxyUser":             {In: godror.ContextWithUserPassw(ctx, proxyUser, proxyPassword, ""), Want: proxyUser},
+		"proxyUserNoPass":       {In: godror.ContextWithUserPassw(ctx, proxyUser, "", ""), Want: proxyUser},
+		"proxyUserwithBrackets": {In: godror.ContextWithUserPassw(ctx, "["+proxyUser+"]", "", ""), Want: proxyUser},
 	}
 	if cs.IsStandalone() {
+		delete(testCases, "proxyUser")
 		delete(testCases, "proxyUserNoPass")
+		delete(testCases, "proxyUserwithBrackets")
 	}
 	for tName, tCase := range testCases {
 		t.Run(tName, func(t *testing.T) {
 			var result string
 			if err = testHeterogeneousDB.QueryRowContext(tCase.In, "SELECT user FROM dual").Scan(&result); err != nil {
-				t.Fatalf("%s: %+v", tName, err)
+				if tName == "proxyUserwithBrackets" {
+					if !strings.Contains(err.Error(), "ORA-00987:") {
+						t.Errorf("%s: unexpected Error %s", tName, err.Error())
+					}
+				} else {
+					t.Fatalf("%s: %+v", tName, err)
+				}
 			}
-			if !strings.EqualFold(tCase.Want, result) {
-				t.Errorf("%s: currentUser got %s, wanted %s", tName, result, tCase.Want)
+			if tName != "proxyUserwithBrackets" {
+				if !strings.EqualFold(tCase.Want, result) {
+					t.Errorf("%s: currentUser got %s, wanted %s", tName, result, tCase.Want)
+				}
 			}
 		})
 
 	}
 
+}
+
+// passing Proxyuser at the time of Go pool creation
+// user = proxyusername[sessionusername], password for proxyusername
+func TestHeterogeneousConnCreationWithProxy(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("HeterogeneousConnCreationWithProxy"), 30*time.Second)
+	defer cancel()
+
+	const sessionUserPassword = "myPassword666myPassword"
+	const sessionUser = "test_hetero_create_sessionUser"
+
+	cs, err := godror.ParseDSN(testConStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	username := cs.Username
+	if !cs.IsStandalone() {
+		cs.Heterogeneous = true
+	}
+	cs.Username += "[" + sessionUser + "]"
+	testHeterogeneousConStr := cs.StringWithPassword()
+	t.Log(testHeterogeneousConStr)
+
+	var testHeterogeneousDB *sql.DB
+	if testHeterogeneousDB, err = sql.Open("godror", testHeterogeneousConStr); err != nil {
+		t.Fatal(fmt.Errorf("%s: %w", testHeterogeneousConStr, err))
+	}
+	defer testHeterogeneousDB.Close()
+	testHeterogeneousDB.SetMaxIdleConns(0)
+
+	testDb.ExecContext(ctx, fmt.Sprintf("DROP USER %s", sessionUser))
+
+	for _, qry := range []string{
+		fmt.Sprintf("CREATE USER %s IDENTIFIED BY "+sessionUserPassword, sessionUser),
+		fmt.Sprintf("GRANT CREATE SESSION TO %s", sessionUser),
+		fmt.Sprintf("ALTER USER %s GRANT CONNECT THROUGH %s", sessionUser, username),
+	} {
+		if _, err = testDb.ExecContext(ctx, qry); err != nil {
+			if strings.Contains(err.Error(), "ORA-01031:") {
+				t.Log("Please issue this:\nGRANT CREATE USER, DROP USER, ALTER USER TO " + username + ";\n" +
+					"GRANT CREATE SESSION TO " + username + " WITH ADMIN OPTION;\n")
+			}
+			t.Skip(fmt.Errorf("%s: %w", qry, err))
+		}
+	}
+	defer func() {
+		testDb.ExecContext(testContext("HeterogeneousConnCreationWithProxy-drop"), "DROP USER "+sessionUser)
+	}()
+	var result string
+	if err = testHeterogeneousDB.QueryRowContext(ctx, "SELECT user FROM dual").Scan(&result); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if !strings.EqualFold(sessionUser, result) {
+		t.Errorf("currentUser got %s, wanted %s", result, sessionUser)
+	}
 }
 
 func TestContextWithUserPassw(t *testing.T) {
@@ -100,7 +182,9 @@ func TestContextWithUserPassw(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs.Heterogeneous = true
+	if !cs.IsStandalone() {
+		cs.Heterogeneous = true
+	}
 	username, password := cs.Username, cs.Password
 	cs.Username = ""
 	cs.Password.Reset()


### PR DESCRIPTION
Add support for ProxyUser in external authentication. 

- In  pooled case as externalAuthentication uses heterogeneous pool,  username is removed as part of poolkey for external authentication. similarly in acquireConn, avoid resetting username, password to empty as the proxyuser/session. user keeps changing in  subsequent queries/getsessions. 

- The session user can be mentioned after enclosing with brackets as [sessionuser] once  the pool is created with empty username/password. For standalone, sessionuser mentioned in. sql.open cant be changed. 

Test cases are covered , taking following link as reference:
https://blogs.oracle.com/opal/external-and-proxy-connection-syntax-examples-for-node-oracledb


standalone=0:
Test Runs:
go test  -run TestExternalAuthIntegration
PASS
ok  	github.com/godror/godror	0.741s

go test  -run TestHeterogeneousPoolIntegration
PASS
ok  	github.com/godror/godror	0.838s

go test  -run TestHeterogeneousConnCreationWithProxy
PASS
ok  	github.com/godror/godror	0.491s

go test  -run TestContextWithUserPassw
PASS
ok  	github.com/godror/godror	0.480s


standalone=1:

go test  -run TestExternalAuthIntegration
PASS
ok  	github.com/godror/godror	1.120s

go test  -run TestHeterogeneousPoolIntegration
PASS
ok  	github.com/godror/godror	0.729s

go test  -run TestHeterogeneousConnCreationWithProxy
PASS
ok  	github.com/godror/godror	0.396s

go test  -run TestContextWithUserPassw
PASS
ok  	github.com/godror/godror	0.201s

