### PR TITLE
bug in NamedToOrderered when query contains a string with a semicolon

### DIFF
--- a/orahlp.go
+++ b/orahlp.go
@@ -387,6 +387,10 @@ func MapToSlice(qry string, metParam func(string) interface{}) (string, []interf
 			if prev == '*' && r == '/' {
 				state = 0
 			}
+		case 4:
+			if r == '\'' {
+				state = 0
+			}
 		case 0:
 			switch r {
 			case '-':
@@ -397,6 +401,8 @@ func MapToSlice(qry string, metParam func(string) interface{}) (string, []interf
 				if prev == '/' {
 					state = 3
 				}
+			case '\'':
+				state = 4
 			case ':':
 				state = 1
 				p = i

--- a/orahlp_test.go
+++ b/orahlp_test.go
@@ -19,10 +19,10 @@ func TestMapToSlice(t *testing.T) {
 	}{
 		{
 			`SELECT NVL(MAX(F_dazon), :dazon) FROM T_spl_level
-			WHERE (F_spl_azon = :lev_azon OR --:lev_azon OR
+			WHERE (to_char(CURRENT_DATE, 'HH:MM') = '00:42' AND F_spl_azon = :lev_azon OR --:lev_azon OR
 			       F_ssz = 0 AND F_lev_azon = /*:lev_azon*/:lev_azon)`,
 			`SELECT NVL(MAX(F_dazon), :1) FROM T_spl_level
-			WHERE (F_spl_azon = :2 OR --:lev_azon OR
+			WHERE (to_char(CURRENT_DATE, 'HH:MM') = '00:42' AND F_spl_azon = :2 OR --:lev_azon OR
 			       F_ssz = 0 AND F_lev_azon = /*:lev_azon*/:3)`,
 			[]interface{}{"dazon", "lev_azon", "lev_azon"},
 		},


### PR DESCRIPTION
Hello,
thank you for making godror. I found a bug in the function `NamedToOrdered` from which I've update an existing test case that is failing without the fix. 

Cheers,

Mickael