### PR TITLE
Remove impossible checks

### DIFF
--- a/z_issue133_test.go
+++ b/z_issue133_test.go
@@ -315,9 +315,6 @@ func issue133Inner(ctx context.Context, t testing.TB, conn *sql.Conn, rowsToInse
 	t.Logf("Merge done, number of rows merged: %d, merge timing: %s\n", totalRowsMerged, dur)
 
 	stmt.Close()
-	if err != nil {
-		return fmt.Errorf("%s: %w", qry, err)
-	}
 	return nil
 }
 

--- a/z_plsql_types_test.go
+++ b/z_plsql_types_test.go
@@ -109,9 +109,6 @@ func (t *MyTable) Scan(src interface{}) error {
 	var i int
 	for i, err = collection.First(); err == nil; i, err = collection.Next(i) {
 		//fmt.Printf("Scan[%d]: %+v\n", i, err)
-		if err != nil {
-			break
-		}
 		var data godror.Data
 		err = collection.GetItem(&data, i)
 		if err != nil {


### PR DESCRIPTION
These errors are already checked early in the code and static analysis
complains that they are impossible conditions.

In the case of z_issue133_test.go the error is checked at the top of the function. Within the if statement above this check there is an alias'ed err which makes it appear this check applies but err exists only within the if statement block.

In the case of z_plsql_types_test.go the for loop checks that `err == nil` immediately before this check. The initial assignment is not exempt from this check.