### PR TITLE
Configurable client character set

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -349,8 +349,11 @@ func (d *drv) initCommonCreateParams(P *C.dpiCommonCreateParams, enableEvents bo
 	}
 
 	// assign encoding and national encoding
-	P.encoding = C.CString(charset)
-	P.nencoding = C.CString(charset)
+	P.encoding, P.nencoding = cUTF8, cUTF8
+	if charset != "" {
+		P.encoding = C.CString(charset)
+		P.nencoding = P.encoding
+	}
 
 	// assign driver name
 	P.driverName = cDriverName

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -43,6 +43,8 @@ const (
 	DefaultMaxLifeTime = 1 * time.Hour
 	//DefaultStandaloneConnection holds the default for standaloneConnection.
 	DefaultStandaloneConnection = false
+	// DefaultCharset holds the default client character set. UTF-8 is a shortcut name for AL32UTF8 in ODPI-C (and not the same as the botched UTF8)
+	DefaultCharset = "UTF-8"
 )
 
 // CommonParams holds the common parameters for pooled or standalone connections.
@@ -60,6 +62,7 @@ type CommonParams struct {
 	// StmtCacheSize of 0 means the default, -1 to disable the stmt cache completely
 	StmtCacheSize           int
 	EnableEvents, NoTZCheck bool
+	Charset                 string
 }
 
 // String returns the string representation of CommonParams.
@@ -93,6 +96,7 @@ func (P CommonParams) String() string {
 	if P.StmtCacheSize != 0 {
 		q.Add("stmtCacheSize", strconv.Itoa(int(P.StmtCacheSize)))
 	}
+	q.Add("charset", P.Charset)
 
 	return q.String()
 }
@@ -259,6 +263,7 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	if P.StmtCacheSize != 0 {
 		q.Add("stmtCacheSize", strconv.Itoa(int(P.StmtCacheSize)))
 	}
+	q.Add("charset", P.Charset)
 	q.Add("poolMinSessions", strconv.Itoa(P.MinSessions))
 	q.Add("poolMaxSessions", strconv.Itoa(P.MaxSessions))
 	if P.MaxSessionsPerShard != 0 {
@@ -297,6 +302,9 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 	P := ConnectionParams{
 		StandaloneConnection: DefaultStandaloneConnection,
 		//CommonParams: CommonParams{ Timezone: time.Local, },
+		CommonParams: CommonParams{
+			Charset: DefaultCharset,
+		},
 		ConnParams: ConnParams{
 			ConnClass: DefaultConnectionClass,
 		},
@@ -379,6 +387,8 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 					P.Username = value
 				case "password":
 					P.Password.secret = value
+				case "charset":
+					P.Charset = value
 				case "alterSession", "onInit", "shardingKey", "superShardingKey":
 					q.Add(key, value)
 				default:

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -43,8 +43,6 @@ const (
 	DefaultMaxLifeTime = 1 * time.Hour
 	//DefaultStandaloneConnection holds the default for standaloneConnection.
 	DefaultStandaloneConnection = false
-	// DefaultCharset holds the default client character set. UTF-8 is a shortcut name for AL32UTF8 in ODPI-C (and not the same as the botched UTF8)
-	DefaultCharset = "UTF-8"
 )
 
 // CommonParams holds the common parameters for pooled or standalone connections.
@@ -96,7 +94,9 @@ func (P CommonParams) String() string {
 	if P.StmtCacheSize != 0 {
 		q.Add("stmtCacheSize", strconv.Itoa(int(P.StmtCacheSize)))
 	}
-	q.Add("charset", P.Charset)
+	if P.Charset != "" {
+		q.Add("charset", P.Charset)
+	}
 
 	return q.String()
 }
@@ -263,7 +263,9 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	if P.StmtCacheSize != 0 {
 		q.Add("stmtCacheSize", strconv.Itoa(int(P.StmtCacheSize)))
 	}
-	q.Add("charset", P.Charset)
+	if P.Charset != "" {
+		q.Add("charset", P.Charset)
+	}
 	q.Add("poolMinSessions", strconv.Itoa(P.MinSessions))
 	q.Add("poolMaxSessions", strconv.Itoa(P.MaxSessions))
 	if P.MaxSessionsPerShard != 0 {
@@ -302,9 +304,6 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 	P := ConnectionParams{
 		StandaloneConnection: DefaultStandaloneConnection,
 		//CommonParams: CommonParams{ Timezone: time.Local, },
-		CommonParams: CommonParams{
-			Charset: DefaultCharset,
-		},
 		ConnParams: ConnParams{
 			ConnClass: DefaultConnectionClass,
 		},


### PR DESCRIPTION
Add a "common" configuration parameter that allows the client character set to be configured.

See #208 for prior discussion.