### PR TITLE
Array of native values must be converted with AsSlice and not AsMapSlice

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -241,7 +241,11 @@ func (O *Object) AsMap(recursive bool) (map[string]interface{}, error) {
 				}
 				continue
 			}
-			if m[a], err = sub.Collection().AsMapSlice(recursive); err != nil {
+			if sub.ObjectType.CollectionOf.Attributes == nil {
+				if m[a], err = sub.Collection().AsSlice(nil); err != nil {
+					return m, fmt.Errorf("%q.AsSlice: %w", a, err)
+				}
+			} else if m[a], err = sub.Collection().AsMapSlice(recursive); err != nil {
 				return m, fmt.Errorf("%q.AsMapSlice: %w", a, err)
 			}
 		}

--- a/z_test.go
+++ b/z_test.go
@@ -4427,3 +4427,75 @@ func TestLobAsStringTypeName(t *testing.T) {
 		t.Error(d)
 	}
 }
+
+func TestObjWithNativeSlice(t *testing.T) {
+	ctx, cancel := context.WithTimeout(testContext("Object"), 10*time.Second)
+	defer cancel()
+	conn, err := testDb.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	testCon, err := godror.DriverConn(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testCon.Close()
+	if err = testCon.Ping(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("dbstats: %#v", testDb.Stats())
+
+	cleanup := func() {
+		testDb.Exec("DROP PROCEDURE test_proc")
+		testDb.Exec("DROP TYPE test_obj")
+		testDb.Exec("DROP TYPE arr_native")
+	}
+	cleanup()
+	crea := []string{
+		`CREATE OR REPLACE TYPE test_obj AS OBJECT (dt arr_native);`,
+		`CREATE OR REPLACE TYPE arr_native AS TABLE OF varchar2(40000);`,
+		`CREATE procedure test_proc(p_oo out test_obj) is
+		BEGIN
+		arr_native.EXTEND;
+		arr_native(arr_native.LAST) := 'let it work';
+		test_obj := test_obj(arr_native);
+		END;`,
+	}
+
+	for _, q := range crea {
+		if _, err = testDb.ExecContext(ctx, q); err != nil {
+			t.Fatal(fmt.Errorf("%s: %w", q, err))
+		}
+	}
+	defer cleanup()
+
+	qry := "CALL test_proc(:1);"
+	stmt, err := conn.PrepareContext(ctx, qry)
+	if err != nil {
+		t.Fatal(fmt.Errorf("%s: %w", qry, err))
+	}
+	defer stmt.Close()
+
+	cOt, err := testCon.GetObjectType(strings.ToUpper("test_obj"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(cOt)
+
+	cO, err := cOt.NewObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(cOt)
+
+	if _, err = stmt.ExecContext(ctx,
+		sql.Out{Dest: cO},
+	); err != nil {
+		t.Error(err)
+	}
+
+	if cO.ObjectType != nil {
+		fmt.Println(cO.AsMap(true))
+	}
+}


### PR DESCRIPTION
Hi,
I found that the array of number or array of string was not converted.
The behavior was that array was initialized with the right length, but no value was inserted into it due the fact that the AsMapSlice was looking for an Object.
The correct way is to call  AsSlice instead of AsMapSlice.