### PR TITLE
fix dsn password exists special characters

### DIFF
--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -776,6 +776,14 @@ func parseUserPassw(dataSourceName string) (user, passw, connectString string) {
 		return "", "", dataSourceName + unquote(extra)
 	}
 
+	// username/"password"
+	if strings.Index(dataSourceName, "/\"") > 0 {
+		if si := strings.Index(dataSourceName, "\""); si > 0 {
+			li := strings.Index(dataSourceName[si+1:], "\"") + si
+			ups = splitQuoted(dataSourceName[li+1:], '@')
+			userpass = []string{dataSourceName[:si-1], dataSourceName[si+1 : li+1]}
+		}
+	}
 	user = unquote(userpass[0])
 	if len(userpass) > 1 {
 		passw = unquote(userpass[1])

--- a/dsn/dsn_test.go
+++ b/dsn/dsn_test.go
@@ -115,6 +115,12 @@ func TestParse(t *testing.T) {
 	wantLibDir.ConnectString = "localhost/orclpdb1"
 	wantLibDir.LibDir = "/Users/cjones/instantclient_19_3"
 
+	wantPassExistsSpecialCharacters1 := wantDefault
+	wantPassExistsSpecialCharacters1.CommonParams.Password = NewPassword("pass@pass")
+	wantPassExistsSpecialCharacters2 := wantDefault
+	wantPassExistsSpecialCharacters2.ConnectString = ""
+	wantPassExistsSpecialCharacters2.CommonParams.Password = NewPassword("pass@pass")
+
 	// From fuzzing
 	for _, in := range []string{
 		"oracle://[]",
@@ -128,8 +134,10 @@ func TestParse(t *testing.T) {
 		In   string
 		Want ConnectionParams
 	}{
-		"simple":   {In: "user/pass@sid", Want: wantDefault},
-		"userpass": {In: "user/pass", Want: wantEmptyConnectString},
+		"simple":                       {In: "user/pass@sid", Want: wantDefault},
+		"userpass":                     {In: "user/pass", Want: wantEmptyConnectString},
+		"passExistsSpecialCharacters1": {In: "user/\"pass@pass\"@sid", Want: wantPassExistsSpecialCharacters1},
+		"passExistsSpecialCharacters2": {In: "user/\"pass@pass\"", Want: wantPassExistsSpecialCharacters2},
 
 		"full": {In: "oracle://user:pass@sid/?poolMinSessions=3&poolMaxSessions=9&poolIncrement=3&connectionClass=TestClassName&standaloneConnection=0&sysoper=1&sysdba=0&poolWaitTimeout=200ms&poolSessionMaxLifetime=4000s&poolSessionTimeout=2000s",
 			Want: ConnectionParams{


### PR DESCRIPTION
If dsn password exists special characters, then password need in double quotes.

ex:
password = pa@ss
dsn = user/"pa@ss"@sid