### PR TITLE
Provide Info about new connection to OnInit method

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1107,13 +1107,13 @@ func (c *conn) ResetSession(ctx context.Context) error {
 		// Just release
 		_ = c.closeNotLocking()
 	}
-	dpiConn, newConnectionCreated, err := c.drv.acquireConn(pool, P)
+	dpiConn, isNew, err := c.drv.acquireConn(pool, P)
 	c.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("%v: %w", err, driver.ErrBadConn)
 	}
 	c.dpiConn = dpiConn
-	ctx = context.WithValue(ctx, dsn.OnInitNewConnectionKey, newConnectionCreated)
+	ctx = context.WithValue(ctx, dsn.OnInitNewConnectionKey, isNew)
 	return c.init(ctx, P.OnInit)
 }
 

--- a/conn.go
+++ b/conn.go
@@ -501,7 +501,7 @@ func (c *conn) init(ctx context.Context, isNew bool, onInit func(ctx context.Con
 		logger.Log("msg", "connection initialized", "conn", c, "haveOnInit", onInit != nil)
 	}
 
-	if c.params.CommonParams.OnInitNewCon && !isNew {
+	if c.params.CommonParams.InitOnNewConn && !isNew {
 		return nil
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -1113,7 +1113,7 @@ func (c *conn) ResetSession(ctx context.Context) error {
 		return fmt.Errorf("%v: %w", err, driver.ErrBadConn)
 	}
 	c.dpiConn = dpiConn
-	ctx = context.WithValue(ctx, dsn.OnInitNewConnectionKey, isNew)
+	ctx = context.WithValue(ctx, dsn.isNewCtxKey, isNew)
 	return c.init(ctx, P.OnInit)
 }
 

--- a/conn.go
+++ b/conn.go
@@ -1107,13 +1107,13 @@ func (c *conn) ResetSession(ctx context.Context) error {
 		// Just release
 		_ = c.closeNotLocking()
 	}
-	dpiConn, err := c.drv.acquireConn(pool, P)
+	dpiConn, newConnectionCreated, err := c.drv.acquireConn(pool, P)
 	c.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("%v: %w", err, driver.ErrBadConn)
 	}
 	c.dpiConn = dpiConn
-
+	ctx = context.WithValue(ctx, dsn.OnInitNewConnectionKey, newConnectionCreated)
 	return c.init(ctx, P.OnInit)
 }
 

--- a/drv.go
+++ b/drv.go
@@ -613,11 +613,9 @@ func (d *drv) createConnFromParams(ctx context.Context, P dsn.ConnectionParams) 
 	if onInit == nil {
 		return conn, err
 	}
-
 	ctx, cancel := context.WithTimeout(ctx, nvlD(conn.params.WaitTimeout, time.Minute))
 	err = onInit(ctx, conn)
 	cancel()
-
 	if err != nil {
 		conn.Close()
 		return nil, err

--- a/drv.go
+++ b/drv.go
@@ -605,7 +605,7 @@ func (d *drv) createConnFromParams(ctx context.Context, P dsn.ConnectionParams) 
 		return conn, err
 	}
 
-	if P.CommonParams.OnInitNewCon && !isNew {
+	if P.CommonParams.InitOnNewConn && !isNew {
 		return conn, nil
 	}
 

--- a/drv.go
+++ b/drv.go
@@ -376,7 +376,7 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 		return nil, false, err
 	}
 
-	dc, newConnectionCreated, err := d.acquireConn(pool, P)
+	dc, isNew, err := d.acquireConn(pool, P)
 	if err != nil {
 		return nil, false, err
 	}
@@ -397,7 +397,7 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 			c.params.Username = pool.params.Username
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), dsn.OnInitNewConnectionKey, newConnectionCreated), nvlD(c.params.WaitTimeout, time.Minute))
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), dsn.OnInitNewConnectionKey, isNew), nvlD(c.params.WaitTimeout, time.Minute))
 	if err := c.init(ctx, getOnInit(&c.params.CommonParams)); err != nil {
 		_ = c.closeNotLocking()
 		return nil, false, err
@@ -412,7 +412,7 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 			_ = c.closeNotLocking()
 		}
 	})
-	return &c, newConnectionCreated, nil
+	return &c, isNew, nil
 }
 
 func (d *drv) acquireConn(pool *connPool, P commonAndConnParams) (*C.dpiConn, bool, error) {
@@ -600,7 +600,7 @@ func (d *drv) createConnFromParams(ctx context.Context, P dsn.ConnectionParams) 
 			return nil, err
 		}
 	}
-	conn, newConnectionCreated, err := d.createConn(pool, commonAndConnParams{CommonParams: P.CommonParams, ConnParams: P.ConnParams})
+	conn, isNew, err := d.createConn(pool, commonAndConnParams{CommonParams: P.CommonParams, ConnParams: P.ConnParams})
 	if err != nil {
 		return conn, err
 	}
@@ -608,7 +608,7 @@ func (d *drv) createConnFromParams(ctx context.Context, P dsn.ConnectionParams) 
 	if onInit == nil {
 		return conn, err
 	}
-	ctx, cancel := context.WithTimeout(context.WithValue(ctx, dsn.OnInitNewConnectionKey, newConnectionCreated), nvlD(conn.params.WaitTimeout, time.Minute))
+	ctx, cancel := context.WithTimeout(context.WithValue(ctx, dsn.OnInitNewConnectionKey, isNew), nvlD(conn.params.WaitTimeout, time.Minute))
 	err = onInit(ctx, conn)
 	cancel()
 	if err != nil {

--- a/drv.go
+++ b/drv.go
@@ -397,7 +397,7 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 			c.params.Username = pool.params.Username
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), dsn.OnInitNewConnectionKey, isNew), nvlD(c.params.WaitTimeout, time.Minute))
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), dsn.isNewCtxKey, isNew), nvlD(c.params.WaitTimeout, time.Minute))
 	if err := c.init(ctx, getOnInit(&c.params.CommonParams)); err != nil {
 		_ = c.closeNotLocking()
 		return nil, false, err
@@ -608,7 +608,7 @@ func (d *drv) createConnFromParams(ctx context.Context, P dsn.ConnectionParams) 
 	if onInit == nil {
 		return conn, err
 	}
-	ctx, cancel := context.WithTimeout(context.WithValue(ctx, dsn.OnInitNewConnectionKey, isNew), nvlD(conn.params.WaitTimeout, time.Minute))
+	ctx, cancel := context.WithTimeout(context.WithValue(ctx, dsn.isNewCtxKey, isNew), nvlD(conn.params.WaitTimeout, time.Minute))
 	err = onInit(ctx, conn)
 	cancel()
 	if err != nil {

--- a/drv.go
+++ b/drv.go
@@ -579,8 +579,8 @@ func (d *drv) acquireConn(pool *connPool, P commonAndConnParams) (*C.dpiConn, bo
 			username, connCreateParams, err)
 	}
 	//use the information from ODPI driver if new connection has been created or it is only pooled
-	newConnctionCreated := connCreateParams.outNewSession == 1
-	return dc, newConnctionCreated, nil
+	isNew := connCreateParams.outNewSession == 1
+	return dc, isNew, nil
 }
 
 // createConnFromParams creates a driver connection given pool parameters and connection

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -45,6 +45,13 @@ const (
 	DefaultStandaloneConnection = false
 )
 
+type OnInitNewConnectionType string
+
+// context key for OnInit method true = newconnection / false = connection from pool
+var (
+	OnInitNewConnectionKey OnInitNewConnectionType = "oinewconn"
+)
+
 // CommonParams holds the common parameters for pooled or standalone connections.
 //
 // For details, see https://oracle.github.io/odpi/doc/structs/dpiCommonCreateParams.html#dpicommoncreateparams

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -101,6 +101,9 @@ func (P CommonParams) String() string {
 	if P.Charset != "" {
 		q.Add("charset", P.Charset)
 	}
+	if P.OnInitNewCon {
+		q.Add("onInitNewConnect", "1")
+	}
 
 	return q.String()
 }
@@ -299,6 +302,7 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 		as.Add(kv[0], kv[1])
 		q.Add("alterSession", strings.TrimSpace(as.String()))
 	}
+	q.Add("onInitNewConnect", B(P.OnInitNewCon))
 	q.Values["onInit"] = P.OnInitStmts
 	q.Add("configDir", P.ConfigDir)
 	q.Add("libDir", P.LibDir)
@@ -434,6 +438,7 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 		{&P.StandaloneConnection, "standaloneConnection"},
 
 		{&P.NoTZCheck, "noTimezoneCheck"},
+		{&P.OnInitNewCon, "onInitNewConnect"},
 	} {
 		s := q.Get(task.Key)
 		if s == "" {

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -57,7 +57,7 @@ type CommonParams struct {
 	// OnInitStmts are executed on session init, iff OnInit is nil.
 	OnInitStmts []string
 	// true: OnInit will be called only by the new session / false: OnInit will called by new or pooled connection
-	OnInitNewCon bool
+	InitOnNewConn bool
 	// AlterSession key-values are set with "ALTER SESSION SET key=value" on session init, iff OnInit is nil.
 	AlterSession [][2]string
 	Timezone     *time.Location
@@ -101,8 +101,8 @@ func (P CommonParams) String() string {
 	if P.Charset != "" {
 		q.Add("charset", P.Charset)
 	}
-	if P.OnInitNewCon {
-		q.Add("onInitNewConnect", "1")
+	if P.InitOnNewConn {
+		q.Add("initOnNewConnection", "1")
 	}
 
 	return q.String()
@@ -302,7 +302,7 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 		as.Add(kv[0], kv[1])
 		q.Add("alterSession", strings.TrimSpace(as.String()))
 	}
-	q.Add("onInitNewConnect", B(P.OnInitNewCon))
+	q.Add("initOnNewConnection", B(P.InitOnNewConn))
 	q.Values["onInit"] = P.OnInitStmts
 	q.Add("configDir", P.ConfigDir)
 	q.Add("libDir", P.LibDir)
@@ -438,7 +438,7 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 		{&P.StandaloneConnection, "standaloneConnection"},
 
 		{&P.NoTZCheck, "noTimezoneCheck"},
-		{&P.OnInitNewCon, "onInitNewConnect"},
+		{&P.InitOnNewConn, "initOnNewConnection"},
 	} {
 		s := q.Get(task.Key)
 		if s == "" {

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -45,13 +45,6 @@ const (
 	DefaultStandaloneConnection = false
 )
 
-type isNewCtxType string
-
-// context key for OnInit method true = newconnection / false = connection from pool
-var (
-	isNewCtxKey isNewCtxType = "oinewconn"
-)
-
 // CommonParams holds the common parameters for pooled or standalone connections.
 //
 // For details, see https://oracle.github.io/odpi/doc/structs/dpiCommonCreateParams.html#dpicommoncreateparams
@@ -63,6 +56,8 @@ type CommonParams struct {
 	OnInit func(context.Context, driver.ConnPrepareContext) error
 	// OnInitStmts are executed on session init, iff OnInit is nil.
 	OnInitStmts []string
+	// true: OnInit will be called only by the new session / false: OnInit will called by new or pooled connection
+	OnInitNewCon bool
 	// AlterSession key-values are set with "ALTER SESSION SET key=value" on session init, iff OnInit is nil.
 	AlterSession [][2]string
 	Timezone     *time.Location

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -45,11 +45,11 @@ const (
 	DefaultStandaloneConnection = false
 )
 
-type OnInitNewConnectionType string
+type isNewCtxType string
 
 // context key for OnInit method true = newconnection / false = connection from pool
 var (
-	OnInitNewConnectionKey OnInitNewConnectionType = "oinewconn"
+	isNewCtxKey isNewCtxType = "oinewconn"
 )
 
 // CommonParams holds the common parameters for pooled or standalone connections.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/godror/godror
+module github.com/stanowawi/godror
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stanowawi/godror
+module github.com/godror/godror
 
 go 1.17
 


### PR DESCRIPTION
Intention for new Feature:
The ODPI Driver provides information if the connection has been newly created, or it is taken from the connection pool ( see doc for dpiConnCreateParams.outNewSession) 
It is really useful to have this information by the OnInit method, to be able to differentiate between  connection from the pool or new connection.
Change:
- get and forward the "outNewSession" info as a return value by createConn & acquireConn  methods (newConnectionCreated true = new connection / false = pooled connection)
- Forward this info to the OnInit Method as a  new context tag. This solution with the context tag doesn't change OnInit signature = is  backwards compatible 
- Create new dsn.OnInitNewConnectionType / OnInitNewConnectionKey to provide unique context key for all users. 

 The whole change is backwards compatible.