### PR TITLE
Nil pointer bugfix and 2 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- NoRetry option to disable re-execution of a statement on ORA-04061, ORA-04065 or ORA-04068
 - WarningAsError option to return ORA-24344 as an error instead of skipping it
 - SetAttribute that sidesteps ORA-21602
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- WarningAsError option to return ORA-24344 as an error instead of skipping it
 - SetAttribute that sidesteps ORA-21602
 
 ### Changed

--- a/conn.go
+++ b/conn.go
@@ -89,6 +89,12 @@ func (c *conn) checkExecNoLOT(f func() C.int) error {
 	}
 	return c.drv.checkExecNoLOT(f)
 }
+func (c *conn) checkExecWithWarning(f func() C.int) error {
+	if c == nil || c.drv == nil {
+		return driver.ErrBadConn
+	}
+	return c.drv.checkExecWithWarning(f)
+}
 
 // used before an ODPI call to force it to return within the context deadline
 func (c *conn) handleDeadline(ctx context.Context) (cleanup func(), err error) {

--- a/drv.go
+++ b/drv.go
@@ -279,6 +279,14 @@ func (d *drv) checkExecNoLOT(f func() C.int) error {
 	return d.getError()
 }
 
+func (d *drv) checkExecWithWarning(f func() C.int) error {
+	runtime.LockOSThread()
+	_ = f()
+	err := d.getError()
+	runtime.UnlockOSThread()
+	return err
+}
+
 func (d *drv) init(configDir, libDir string) error {
 	d.mu.RLock()
 	ok := d.pools != nil && d.timezones != nil && d.dpiContext != nil

--- a/stmt.go
+++ b/stmt.go
@@ -2731,7 +2731,7 @@ func (c *conn) dataSetLOBOne(ctx context.Context, dv *C.dpiVar, data []C.dpiData
 				logger.Error("setLOB", "type", typ, "error", err)
 			}
 		} else {
-			if logger.Enabled(ctx, slog.LevelDebug) {
+			if logger != nil && logger.Enabled(ctx, slog.LevelDebug) {
 				logger.Debug("setLOB", "type", typ, "size", lobSize, "error", err)
 			}
 			if int64(lobSize) != int64(written) {


### PR DESCRIPTION
Hi @tgulacsi,

I want so submit two minor changes that I need for my current project:

WarningAsError option mimics the behaviour of SQL*PLUS which gives feedback when a PL/SQL object was created successfully, but had compilation errors.

NoRetry option to prevent re-execution on certain errors. Although I think the re-try is generally a good call, re-execution might cause side-effects. For example in the following statement procedure1 and procedure2 will be re-executed which in my case must not happen.
```
BEGIN
  procedure1;
  procedure2;
  procedure3; -- ORA-04068 happens here
END;
```
Please let me know what you think and whether I should change anything.