### PR TITLE
- Adding support for Vector and Sparse Vector

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -123,7 +123,7 @@ func (r *rows) ColumnTypeLength(index int) (length int64, ok bool) {
 		C.DPI_ORACLE_TYPE_BFILE,
 		C.DPI_NATIVE_TYPE_LOB,
 		C.DPI_ORACLE_TYPE_JSON, C.DPI_ORACLE_TYPE_JSON_OBJECT, C.DPI_ORACLE_TYPE_JSON_ARRAY,
-		C.DPI_ORACLE_TYPE_XMLTYPE:
+		C.DPI_ORACLE_TYPE_XMLTYPE, C.DPI_ORACLE_TYPE_VECTOR:
 		return math.MaxInt64, true
 	default:
 		return 0, false
@@ -191,6 +191,8 @@ func (r *rows) ColumnTypeDatabaseTypeName(index int) string {
 		return "JSON"
 	case C.DPI_ORACLE_TYPE_XMLTYPE:
 		return "XMLTYPE"
+	case C.DPI_ORACLE_TYPE_VECTOR:
+		return "VECTOR"
 	default:
 		return fmt.Sprintf("OTHER[%d]", r.columns[index].OracleType)
 	}
@@ -272,6 +274,8 @@ func (r *rows) ColumnTypeScanType(index int) reflect.Type {
 		return reflect.TypeOf(JSONObject{})
 	case C.DPI_ORACLE_TYPE_JSON_ARRAY:
 		return reflect.TypeOf(JSONArray{})
+	case C.DPI_ORACLE_TYPE_VECTOR:
+		return reflect.TypeOf(Vector{})
 	default:
 		return reflect.TypeOf("")
 	}
@@ -678,6 +682,25 @@ func (r *rows) Next(dest []driver.Value) error {
 				continue
 			}
 			dest[i] = JSONArray{dpiJsonArray: ((*C.dpiJsonArray)(unsafe.Pointer(&d.value)))}
+		case C.DPI_ORACLE_TYPE_VECTOR, C.DPI_NATIVE_TYPE_VECTOR:
+			if isNull {
+				dest[i] = Vector{}
+				continue
+			}
+			var (
+				vectorInfo C.dpiVectorInfo
+				err        error
+			)
+			if err = r.checkExec(func() C.int {
+				return C.dpiVector_getValue(C.dpiData_getVector(d),
+					&vectorInfo)
+			}); err != nil {
+				return err
+			}
+			dest[i], err = GetVectorValue(&vectorInfo)
+			if err != nil {
+				return err
+			}
 
 		default:
 			return fmt.Errorf("unsupported column type %d", typ)

--- a/vector.go
+++ b/vector.go
@@ -37,6 +37,12 @@ type Vector struct {
 
 // SetVectorValue converts a Go `Vector` into a godror data type.
 func SetVectorValue(c *conn, v *Vector, data *C.dpiData) error {
+	if vi, err := c.ClientVersion(); err != nil {
+		return err
+	} else if vi.Version < 23 || vi.Version == 23 && vi.Release < 7 {
+		return fmt.Errorf("clientVersion is old (%s, sparse vector needs at least 23.7)", vi.String())
+	}
+
 	var vectorInfo C.dpiVectorInfo
 	var valuesPtr unsafe.Pointer
 	var format C.uint8_t

--- a/vector.go
+++ b/vector.go
@@ -57,24 +57,12 @@ func SetVectorValue(c *conn, v *Vector, data *C.dpiData) error {
 	case []int8:
 		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_INT8, 1
 		if numDims > 0 {
-			ptr := (*C.int8_t)(C.malloc(C.size_t(numDims)))
-			defer C.free(unsafe.Pointer(ptr))
-			cArray := unsafe.Slice((*int8)(unsafe.Pointer(ptr)), numDims)
-			for i, v := range values {
-				cArray[i] = int8(v)
-			}
-			valuesPtr = unsafe.Pointer(ptr)
+			valuesPtr = unsafe.Pointer(&values[0])
 		}
 	case []uint8:
 		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_BINARY, 1
 		if numDims > 0 {
-			ptr := (*C.uint8_t)(C.malloc(C.size_t(numDims)))
-			defer C.free(unsafe.Pointer(ptr))
-			cArray := unsafe.Slice((*uint8)(unsafe.Pointer(ptr)), numDims)
-			for i, v := range values {
-				cArray[i] = uint8(v)
-			}
-			valuesPtr = unsafe.Pointer(ptr)
+			valuesPtr = unsafe.Pointer(&values[0])
 		}
 	default:
 		return fmt.Errorf("SetVectorValue Unsupported type: %T in Vector Values", v.Values)
@@ -92,6 +80,8 @@ func SetVectorValue(c *conn, v *Vector, data *C.dpiData) error {
 			for i, val := range v.Indices {
 				cArray[i] = C.uint32_t(val)
 			}
+			// below causes hang for uint32 alone ..
+			//sparseIndices = (*C.uint32_t)(unsafe.Pointer(&(v.Indices[0])))
 		}
 		vectorInfo.numDimensions = C.uint32_t(v.Dimensions)
 	} else {

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,168 @@
+// Copyright 2025 The Godror Authors
+//
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+package godror
+
+/*
+#include <stdlib.h>
+#include "dpiImpl.h"
+
+// C Wrapper Function to Set the Dimensions Union Field
+void setVectorInfoDimensions(dpiVectorInfo *info, void *ptr) {
+    info->dimensions.asPtr = ptr;
+}
+
+// C Wrapper Function to Get the Dimensions Union Field
+void* getVectorInfoDimensions(dpiVectorInfo *info) {
+    return info->dimensions.asPtr;
+}
+
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Vector holds the embedding VECTOR column starting from 23ai.
+type Vector struct {
+	Dimensions uint32      // Total dimensions of the vector.
+	Indices    []uint32    // Indices of non-zero values (sparse format).
+	Values     interface{} // Non-zero values (sparse format) or all values (dense format).
+	IsSparse   bool        // Flag to detect if it's a sparse vector
+}
+
+// SetVectorValue converts a Go `Vector` into a godror data type.
+func SetVectorValue(c *conn, v *Vector, data *C.dpiData) error {
+	var vectorInfo C.dpiVectorInfo
+	var valuesPtr unsafe.Pointer
+	var format C.uint8_t
+	var dimensionSize uint8
+	var numDims int
+
+	switch values := (*v).Values.(type) {
+	case []float32:
+		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_FLOAT32, 4
+		if numDims > 0 {
+			valuesPtr = unsafe.Pointer(&values[0])
+		}
+	case []float64:
+		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_FLOAT64, 8
+		if numDims > 0 {
+			valuesPtr = unsafe.Pointer(&values[0])
+		}
+	case []int8:
+		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_INT8, 1
+		if numDims > 0 {
+			ptr := (*C.int8_t)(C.malloc(C.size_t(numDims)))
+			defer C.free(unsafe.Pointer(ptr))
+			cArray := unsafe.Slice((*int8)(unsafe.Pointer(ptr)), numDims)
+			for i, v := range values {
+				cArray[i] = int8(v)
+			}
+			valuesPtr = unsafe.Pointer(ptr)
+		}
+	case []uint8:
+		numDims, format, dimensionSize = len(values), C.DPI_VECTOR_FORMAT_BINARY, 1
+		if numDims > 0 {
+			ptr := (*C.uint8_t)(C.malloc(C.size_t(numDims)))
+			defer C.free(unsafe.Pointer(ptr))
+			cArray := unsafe.Slice((*uint8)(unsafe.Pointer(ptr)), numDims)
+			for i, v := range values {
+				cArray[i] = uint8(v)
+			}
+			valuesPtr = unsafe.Pointer(ptr)
+		}
+	default:
+		return fmt.Errorf("SetVectorValue Unsupported type: %T in Vector Values", v.Values)
+	}
+	C.setVectorInfoDimensions(&vectorInfo, valuesPtr) //update values
+
+	// update sparse indices and numDimensions
+	var sparseIndices *C.uint32_t = nil
+	numSparseValues := len((*v).Indices)
+	if v.IsSparse || numSparseValues > 0 {
+		if numSparseValues > 0 {
+			sparseIndices = (*C.uint32_t)(C.malloc(C.size_t(numSparseValues) * C.size_t(unsafe.Sizeof(C.uint32_t(0)))))
+			defer C.free(unsafe.Pointer(sparseIndices))
+			cArray := unsafe.Slice((*C.uint32_t)(unsafe.Pointer(sparseIndices)), numSparseValues)
+			for i, val := range v.Indices {
+				cArray[i] = C.uint32_t(val)
+			}
+		}
+		vectorInfo.numDimensions = C.uint32_t(v.Dimensions)
+	} else {
+		// update numDimensions for Dense
+		if format == C.DPI_VECTOR_FORMAT_BINARY {
+			numDims *= 8 // Each byte represents 8 dimensions.
+		}
+		vectorInfo.numDimensions = C.uint32_t(numDims)
+	}
+
+	// Populate vectorInfo.
+	vectorInfo.format = format
+	vectorInfo.dimensionSize = C.uint8_t(dimensionSize)
+	vectorInfo.numSparseValues = C.uint32_t(numSparseValues)
+	vectorInfo.sparseIndices = (*C.uint32_t)(sparseIndices)
+
+	// Set vector value.
+	if err := c.checkExec(func() C.int {
+		return C.dpiVector_setValue(C.dpiData_getVector(data), &vectorInfo)
+	}); err != nil {
+		return fmt.Errorf("SetVectorValue %w", err)
+	}
+	return nil
+}
+
+// GetVectorValue converts a C `dpiVectorInfo` struct into a Go `Vector`
+func GetVectorValue(vectorInfo *C.dpiVectorInfo) (Vector, error) {
+	var values interface{}
+	var indices []uint32
+	var isSparse bool
+
+	var nonZeroVal = vectorInfo.numDimensions
+
+	// create Indices
+	if vectorInfo.numSparseValues > 0 {
+		isSparse = true
+		nonZeroVal = vectorInfo.numSparseValues
+		indices = make([]uint32, vectorInfo.numSparseValues)
+		ptr := unsafe.Slice((*C.uint32_t)(unsafe.Pointer(vectorInfo.sparseIndices)), int(vectorInfo.numSparseValues))
+		for i, v := range ptr {
+			indices[i] = uint32(v)
+		}
+	}
+
+	// create Values
+	switch vectorInfo.format {
+	case C.DPI_VECTOR_FORMAT_FLOAT32:
+		ptr := unsafe.Slice((*float32)(unsafe.Pointer(C.getVectorInfoDimensions(vectorInfo))), int(vectorInfo.numDimensions))
+		values = make([]float32, nonZeroVal)
+		copy(values.([]float32), ptr)
+	case C.DPI_VECTOR_FORMAT_FLOAT64:
+		ptr := unsafe.Slice((*float64)(unsafe.Pointer(C.getVectorInfoDimensions(vectorInfo))), int(vectorInfo.numDimensions))
+		values = make([]float64, nonZeroVal)
+		copy(values.([]float64), ptr)
+	case C.DPI_VECTOR_FORMAT_INT8:
+		ptr := unsafe.Slice((*int8)(unsafe.Pointer(C.getVectorInfoDimensions(vectorInfo))), int(vectorInfo.numDimensions))
+		values = make([]int8, nonZeroVal)
+		copy(values.([]int8), ptr)
+	case C.DPI_VECTOR_FORMAT_BINARY:
+		size := vectorInfo.numDimensions / 8
+		ptr := unsafe.Slice((*uint8)(unsafe.Pointer(C.getVectorInfoDimensions(vectorInfo))), int(vectorInfo.numDimensions))
+		values = make([]uint8, size)
+		copy(values.([]uint8), ptr)
+	default:
+		return Vector{}, fmt.Errorf("GetVectorValue Unknown VECTOR format: %d", vectorInfo.format)
+	}
+
+	return Vector{
+		Indices:    indices,
+		Dimensions: uint32(vectorInfo.numDimensions),
+		Values:     values,
+		IsSparse:   isSparse,
+	}, nil
+}

--- a/z_vector_test.go
+++ b/z_vector_test.go
@@ -1,0 +1,445 @@
+// Copyright 2025 The Godror Authors
+//
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+package godror_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	godror "github.com/godror/godror"
+)
+
+func compareDenseVector(t *testing.T, id godror.Number, got godror.Vector, expected godror.Vector) {
+	t.Helper()
+	if !reflect.DeepEqual(got.Values, expected.Values) {
+		t.Errorf("ID %v: expected %v, got %v", id, expected.Values, got.Values)
+	}
+}
+
+func compareSparseVector(t *testing.T, id godror.Number, got godror.Vector, expected godror.Vector) {
+	t.Helper()
+	if !reflect.DeepEqual(got.Values, expected.Values) {
+		t.Errorf("ID %s: Sparse godror.Vector values mismatch. Got %+v, expected %+v", id, got.Values, expected.Values)
+	}
+	if !reflect.DeepEqual(got.Indices, expected.Indices) {
+		t.Errorf("ID %s: Sparse godror.Vector indices mismatch. Got %+v, expected %+v", id, got.Indices, expected.Indices)
+	}
+	if got.Dimensions != expected.Dimensions {
+		t.Errorf("ID %s: Sparse godror.Vector dimensions mismatch. Got %d, expected %d", id, got.Dimensions, expected.Dimensions)
+	}
+}
+
+// It Verifies returning godror.Vector columns in outbinds
+func TestVectorOutBinds(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("OutBindsVector"), 30*time.Second)
+	defer cancel()
+
+	conn, err := testDb.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	tbl := "test_vector_outbind" + tblSuffix
+	conn.ExecContext(ctx, "DROP TABLE "+tbl)
+	_, err = conn.ExecContext(ctx,
+		`CREATE TABLE `+tbl+` (
+			id NUMBER(6), 
+			image_vector Vector, 
+			graph_vector Vector(5, float32, SPARSE), 
+			int_vector Vector(3, int8), 
+			float_vector Vector(4, float64), 
+			sparse_int_vector Vector(4, int8, SPARSE)
+		)`,
+	)
+	if err != nil {
+		if errIs(err, 902, "invalid datatype") {
+			t.Skip(err)
+		}
+		t.Fatal(err)
+	}
+	t.Logf("Vector table %q created", tbl)
+	defer testDb.Exec("DROP TABLE " + tbl)
+
+	stmt, err := conn.PrepareContext(ctx,
+		`INSERT INTO `+tbl+` (id, image_vector, graph_vector, int_vector, float_vector, sparse_int_vector) 
+		 VALUES (:1, :2, :3, :4, :5, :6) RETURNING image_vector, graph_vector, int_vector, float_vector, sparse_int_vector INTO :7, :8, :9, :10, :11`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	// Test values
+	id := godror.Number("1")
+	vectors := []godror.Vector{
+		{Values: []float32{1.1, 2.2, 3.3}}, // image_vector
+		{Values: []float32{0.5, 1.2, -0.9}, Indices: []uint32{0, 2, 3}, Dimensions: 5, IsSparse: true}, // graph_vector
+		{Values: []int8{1, -5, 3}},                  // int_vector
+		{Values: []float64{10.5, 20.3, -5.5, 3.14}}, // float_vector
+		{Values: []int8{-1, 4, -7}, Indices: []uint32{1, 2, 3}, Dimensions: 4, IsSparse: true}, // sparse_int_vector
+	}
+	outVectors := make([]godror.Vector, len(vectors))
+
+	_, err = stmt.ExecContext(ctx, 1, vectors[0], vectors[1], vectors[2], vectors[3], vectors[4],
+		sql.Out{Dest: &outVectors[0]}, sql.Out{Dest: &outVectors[1]},
+		sql.Out{Dest: &outVectors[2]}, sql.Out{Dest: &outVectors[3]}, sql.Out{Dest: &outVectors[4]})
+	if err != nil {
+		t.Fatalf("ExecContext failed: %v", err)
+	}
+
+	// Validate out bind values
+	for i, v := range vectors {
+		if v.IsSparse {
+			compareSparseVector(t, id, outVectors[i], v)
+		} else {
+			compareDenseVector(t, id, outVectors[i], v)
+		}
+	}
+}
+
+// Helper function to generate random batch data
+func generateRandomBatch(size int) ([]godror.Number, []godror.Vector, []godror.Vector, []*godror.Vector, []*godror.Vector) {
+	ids := make([]godror.Number, 2*size)
+	images := make([]godror.Vector, size)
+	graphs := make([]godror.Vector, size)
+	imagesPtr := make([]*godror.Vector, size)
+	graphsPtr := make([]*godror.Vector, size)
+
+	for i := 0; i < size; i++ {
+		ids[i] = godror.Number(strconv.Itoa(i))
+		images[i] = godror.Vector{Values: randomFloat32Slice(3)}
+		graphs[i] = godror.Vector{
+			Values:     randomFloat32Slice(3),
+			Indices:    []uint32{0, 1, 2},
+			Dimensions: 5,
+			IsSparse:   true,
+		}
+	}
+	for i := 0; i < size; i++ {
+		ids[size+i] = godror.Number(strconv.Itoa(size + i))
+		imagesPtr[i] = &godror.Vector{Values: randomFloat32Slice(3)}
+		graphsPtr[i] = &godror.Vector{
+			Values:     randomFloat32Slice(3),
+			Indices:    []uint32{0, 1, 2},
+			Dimensions: 5,
+		}
+	}
+	return ids, images, graphs, imagesPtr, graphsPtr
+}
+
+// Helper function to generate a random single row
+func generateRandomRow(id int) (godror.Number, godror.Vector, godror.Vector) {
+	return godror.Number(strconv.Itoa(id)),
+		godror.Vector{Values: randomFloat32Slice(3)},
+		godror.Vector{
+			Values:     randomFloat32Slice(3),
+			Indices:    []uint32{0, 1, 2},
+			Dimensions: 5,
+			IsSparse:   true,
+		}
+}
+
+// Generates a slice of random float32 numbers
+func randomFloat32Slice(size int) []float32 {
+	slice := make([]float32, size)
+	for i := range slice {
+		slice[i] = rand.Float32() * 10
+	}
+	return slice
+}
+
+// It Verifies batch insert of Vector columns and verify the inserted rows.
+func TestVectorReadWriteBatch(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("ReadWriteVector"), 30*time.Second)
+	defer cancel()
+	conn, err := testDb.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	tbl := "test_vector_batch" + tblSuffix
+	conn.ExecContext(ctx, "DROP TABLE "+tbl)
+	_, err = conn.ExecContext(ctx,
+		"CREATE TABLE "+tbl+" (id NUMBER(6), image_vector Vector, graph_vector Vector(5, float32, SPARSE) )", //nolint:gas
+	)
+	if err != nil {
+		if errIs(err, 902, "invalid datatype") {
+			t.Skip(err)
+		}
+		t.Fatal(err)
+	}
+	t.Logf(" Vector table  %q: ", tbl)
+
+	defer testDb.Exec(
+		"DROP TABLE " + tbl, //nolint:gas
+	)
+
+	stmt, err := conn.PrepareContext(ctx,
+		"INSERT INTO "+tbl+" (id, image_vector, graph_vector) VALUES (:1, :2, :3)", //nolint:gas
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	// Generate random batch values
+	const batchSize = 10
+	ids, images, graphs, imagesPtr, graphsPtr := generateRandomBatch(batchSize)
+
+	// Insert batch
+	if _, err = stmt.ExecContext(ctx, ids[:batchSize], images, graphs); err != nil {
+		t.Fatalf("Batch insert failed: %v", err)
+	}
+
+	// Insert batch Pointers
+	if _, err = stmt.ExecContext(ctx, ids[batchSize:], imagesPtr, graphsPtr); err != nil {
+		t.Fatalf("Batch insert failed: %v", err)
+	}
+
+	// Insert a single row
+	lastID1, lastImage, lastGraph := generateRandomRow(2 * batchSize)
+	if _, err = stmt.ExecContext(ctx, lastID1, lastImage, lastGraph); err != nil {
+		t.Fatalf("Single insert failed: %v", err)
+	}
+
+	// Insert a single rowPtr
+	lastID2, lastImage2, lastGraph2 := generateRandomRow((2 * batchSize) + 1)
+	if _, err = stmt.ExecContext(ctx, lastID2, &lastImage2, &lastGraph2); err != nil {
+		t.Fatalf("Single insert failed: %v", err)
+	}
+
+	// Validate inserted rows
+	rows, err := conn.QueryContext(ctx, "SELECT id, image_vector, graph_vector FROM "+tbl)
+	if err != nil {
+		t.Fatalf("Select query failed: %v", err)
+	}
+	defer rows.Close()
+
+	expectedIDs := append(ids, lastID1, lastID2)
+	expectedImages := images
+	expectedGraphs := graphs
+
+	// Include pointer-based vectors
+	for i := range imagesPtr {
+		expectedImages = append(expectedImages, *imagesPtr[i])
+		expectedGraphs = append(expectedGraphs, *graphsPtr[i])
+	}
+
+	// Include single rows and pointer single rows
+	expectedImages = append(expectedImages, lastImage)
+	expectedImages = append(expectedImages, lastImage2)
+	expectedGraphs = append(expectedGraphs, lastGraph)
+	expectedGraphs = append(expectedGraphs, lastGraph2)
+
+	index := 0
+	for rows.Next() {
+		var id godror.Number
+		var image, graph godror.Vector
+		if err := rows.Scan(&id, &image, &graph); err != nil {
+			t.Fatalf("Row scan failed: %v", err)
+		}
+
+		// Ensure the number of rows matches expectations
+		if index >= len(expectedIDs) {
+			t.Fatalf("More rows returned than expected! Expected: %d, Got: %d", len(expectedIDs), index+1)
+		}
+
+		// Verify vector values
+		t.Logf("Verifying row ID: %s", id)
+		compareDenseVector(t, expectedIDs[index], image, expectedImages[index])
+		compareSparseVector(t, expectedIDs[index], graph, expectedGraphs[index])
+
+		index++
+	}
+}
+
+// Generates test vectors
+func generateTestVectors() (godror.Number, []godror.Vector) {
+	return godror.Number("1"), []godror.Vector{
+		{Values: []float32{1.1, 2.2, 3.3}}, // image_vector
+		{Values: []float32{0.5, 1.2, -0.9}, Indices: []uint32{0, 2, 3}, Dimensions: 5, IsSparse: true}, // graph_vector
+		{Values: []int8{1, -5, 3}},                  // int_vector
+		{Values: []float64{10.5, 20.3, -5.5, 3.14}}, // float_vector
+		{Values: []int8{-1, 4, -7}, Indices: []uint32{1, 2, 3}, Dimensions: 4, IsSparse: true}, // sparse_int_vector
+	}
+}
+
+// Validates dense and sparse vectors
+func validateVectors(t *testing.T, id godror.Number, expected, actual []godror.Vector) {
+	compareDenseVector(t, id, actual[0], expected[0])
+	compareSparseVector(t, id, actual[1], expected[1])
+	compareDenseVector(t, id, actual[2], expected[2])
+	compareDenseVector(t, id, actual[3], expected[3])
+	compareSparseVector(t, id, actual[4], expected[4])
+}
+
+// It Verifies Flex storage godror.Vector columns.
+func TestVectorFlex(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("BindsFlexVector"), 30*time.Second)
+	defer cancel()
+
+	conn, err := testDb.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	tbl := "test_vector_flexbind" + tblSuffix
+	conn.ExecContext(ctx, "DROP TABLE "+tbl)
+	_, err = conn.ExecContext(ctx,
+		`CREATE TABLE `+tbl+` (
+			id NUMBER(6), 
+			image_vector Vector(*,*),
+			graph_vector Vector(*, *, SPARSE), 
+			int_vector Vector(*, *), 
+			float_vector Vector(*, *), 
+			sparse_int_vector Vector(*, *, SPARSE)
+		)`,
+	)
+	if err != nil {
+		if errIs(err, 902, "invalid datatype") {
+			t.Skip(err)
+		}
+		t.Fatal(err)
+	}
+	t.Logf("Vector table %q created", tbl)
+	defer testDb.Exec("DROP TABLE " + tbl)
+
+	stmt, err := conn.PrepareContext(ctx,
+		`INSERT INTO `+tbl+` (id, image_vector, graph_vector, int_vector, float_vector, sparse_int_vector) 
+		 VALUES (:1, :2, :3, :4, :5, :6) RETURNING image_vector, graph_vector, int_vector, float_vector, sparse_int_vector INTO :7, :8, :9, :10, :11`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	id, expectedVectors := generateTestVectors()
+	var outVectors [5]godror.Vector
+
+	_, err = stmt.ExecContext(ctx, id, expectedVectors[0], expectedVectors[1], expectedVectors[2], expectedVectors[3], expectedVectors[4],
+		sql.Out{Dest: &outVectors[0]}, sql.Out{Dest: &outVectors[1]}, sql.Out{Dest: &outVectors[2]}, sql.Out{Dest: &outVectors[3]}, sql.Out{Dest: &outVectors[4]})
+	if err != nil {
+		t.Fatalf("ExecContext failed: %v", err)
+	}
+
+	// Validate inserted values
+	validateVectors(t, id, expectedVectors, outVectors[:])
+
+	// Fetch inserted values
+	row := conn.QueryRowContext(ctx, fmt.Sprintf(`SELECT image_vector, graph_vector, int_vector, float_vector, sparse_int_vector FROM %s WHERE id = :1`, tbl), id)
+	err = row.Scan(&outVectors[0], &outVectors[1], &outVectors[2], &outVectors[3], &outVectors[4])
+	if err != nil {
+		t.Errorf("Select failed for ID %s: %v", id, err)
+	}
+
+	// Validate fetched values
+	validateVectors(t, id, expectedVectors, outVectors[:])
+}
+
+// It Verifies Passing Pointer to Vector type to avoid copies
+func TestVectorPointerCases(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("VectorErrors"), 30*time.Second)
+	defer cancel()
+
+	conn, err := testDb.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	tbl := "test_vector_pointers" + tblSuffix
+	conn.ExecContext(ctx, "DROP TABLE "+tbl)
+	_, err = conn.ExecContext(ctx,
+		`CREATE TABLE `+tbl+` (
+			id NUMBER(6), 
+			flex_dense_vector1 Vector(*,*),
+			flex_sparse_vector1 Vector(*, *, SPARSE), 
+			flex_dense_vector2 Vector(*, *), 
+			flex_sparse_vector2 Vector(*, *, SPARSE)
+		)`,
+	)
+	if err != nil {
+		if errIs(err, 902, "invalid datatype") {
+			t.Skip(err)
+		}
+		t.Fatal(err)
+	}
+	t.Logf("Vector table %q created", tbl)
+	defer testDb.Exec("DROP TABLE " + tbl)
+
+	stmt, err := conn.PrepareContext(ctx,
+		`INSERT INTO `+tbl+` (id, flex_dense_vector1, flex_sparse_vector1, flex_dense_vector2, flex_sparse_vector2) 
+		 VALUES (:1, :2, :3, :4, :5) `,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	// Test values
+	var emptyVector godror.Vector
+	var sparseVec1 = godror.Vector{
+		Values:     []float32{0.5, 1.2, -0.9},
+		Indices:    []uint32{0, 2, 3},
+		Dimensions: 5,
+	}
+	var sparseVec2 = godror.Vector{
+		Values:     []int8{1, -5, 3},
+		Indices:    []uint32{1, 2, 3},
+		Dimensions: 4,
+	}
+	var nilPtrEmbedding *godror.Vector
+
+	// Execute insertion
+	_, err = stmt.ExecContext(ctx, 1, emptyVector, &sparseVec1, nilPtrEmbedding, sparseVec2)
+	if err != nil {
+		t.Fatalf("ExecContext failed: %v", err)
+	}
+
+	// Query results
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, flex_dense_vector1, flex_sparse_vector1, flex_dense_vector2, flex_sparse_vector2 
+		FROM %s`, tbl))
+	if err != nil {
+		t.Errorf("QueryContext failed: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	// Validate results
+	var id godror.Number
+	var dense1, sparse1, sparse2 godror.Vector
+	var dense2 interface{}
+
+	for rows.Next() {
+		if err := rows.Scan(&id, &dense1, &sparse1, &dense2, &sparse2); err != nil {
+			t.Errorf("Scan failed: %v", err)
+			continue
+		}
+
+		compareDenseVector(t, id, dense1, emptyVector)
+		compareSparseVector(t, id, sparse1, sparseVec1)
+		if v, ok := dense2.(godror.Vector); ok {
+			compareDenseVector(t, id, v, emptyVector)
+		} else {
+			t.Errorf("Invalid vector type for dense2: %v", dense2)
+		}
+		compareSparseVector(t, id, sparse2, sparseVec2)
+	}
+}

--- a/z_vector_test.go
+++ b/z_vector_test.go
@@ -254,7 +254,7 @@ func TestVectorReadWriteBatch(t *testing.T) {
 	}
 
 	// Validate inserted rows
-	rows, err := conn.QueryContext(ctx, "SELECT id, image_vector, graph_vector FROM "+tbl)
+	rows, err := conn.QueryContext(ctx, "SELECT id, image_vector, graph_vector FROM "+tbl + " ORDER BY id")
 	if err != nil {
 		t.Fatalf("Select query failed: %v", err)
 	}


### PR DESCRIPTION
### Description

Added 23ai [vector](https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/create-tables-using-vector-data-type.html) support. 

Dense  vector (`VECTOR`) and Sparse vector (`VECTOR(dims, format, SPARSE)`) support has been added. 

A new type, Vector is added to encapsulate Vector and Sparse Vector data.

```
type Vector struct {
	Dimensions uint32      // Total dimensions of the vector.
	Indices    []uint32    // Indices of non-zero values (sparse format).
	Values     interface{} // Non-zero values (sparse format) or all values (dense format).
	IsSparse   bool        // Flag to detect if it's a sparse vector
}
```

New Column MetaData of Vector is added
- VectorFormat -> It represents one of the formats: float32, float64, int8, uint8 (Binary vector)
- VectorFlags -> Indicates if Vector is having flexible dimensions, Sparse
- VectorDimensions -> Number of Dimensions.
 
### Example Usage:

```
CREATE TABLE tbl (id NUMBER(6), embedding Vector)
stmt, err := conn.PrepareContext(ctx,"INSERT INTO tbl (id, embedding) VALUES (:1, :2)")
if _, err = stmt.ExecContext(ctx, 1, &godror.Vector{Values: []float32{1.1, 2.2, 3.3}}); err != nil {
    log.Fatalf("insert failed: %v", err)
}
```

**Bind examples:**

**- Dense Vector** 
godror.Vector{Values: []float32{1.1, 2.2, 3.3}} // float32 storage format
&godror.Vector{Values: []float64{1.1, 2.2, 3.3}} // float64 storage format , passing address of godror.Vector


**- Sparse Vector**
- {Values: []int8{-1, 4, -7}, Indices: []uint32{1, 2, 3}, Dimensions: 4}, // int8 storage format Sparse Vector
-  {Values: []float32{-1, 4, -7}, Indices: []uint32{1, 2, 3}, Dimensions: 4}, // float32 storage format Sparse Vector

On reading from DB, we get the godror.Vector type returned.

```
row := conn.QueryRowContext(ctx, fmt.Sprintf(`SELECT embedding from tbl`))
var outVal godror.Vector
err = row.Scan(&outVal)
```
	

**Note:** 
1. generics like below is explored but as its not available until go 1.18 , it is not considered.
```
 // Storage Format supported types
type Format interface {
	int8 | float32 | float64 | uint8
}

// Vector holds the embedding VECTOR column starting from 23ai.
type Vector[T Format] struct {
	Indices    []uint32 // Indices of non-zero values (sparse format)
	Dimensions uint32   // Total dimensions of the vector (can be set explicitly)
	Values     []T      // Non-zero values (sparse format) or all values (dense format)
	IsSparse   bool     // Flag to detect if it's a sparse vector
}

```
2. In SetVectorValue function, when I wanted to pass go slice to C pointers, It works fine for float32, float64 but did not work for uint32 slices. Hence  I am doing malloc and free for uint32_t, uint8 and int8 slices.


