### PR TITLE
Queue.Dequeue: limit messages to 1 if there are no messages in the queue for #382

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -10,7 +10,6 @@ package godror
 #include "dpiImpl.h"
 */
 import "C"
-
 import (
 	"context"
 	"database/sql/driver"
@@ -95,7 +94,7 @@ func NewQueue(ctx context.Context, execer Execer, name string, payloadObjectType
 			cx.Close()
 			return nil, err
 		}
-		// fmt.Printf("cx=%p cx2=%p\n", cx.(*conn).dpiConn, cx2.(*conn).dpiConn)
+		//fmt.Printf("cx=%p cx2=%p\n", cx.(*conn).dpiConn, cx2.(*conn).dpiConn)
 		if cx.(*conn).dpiConn != cx2.(*conn).dpiConn {
 			execerIsPool = true
 			cx2.Close()
@@ -323,7 +322,6 @@ func (Q *Queue) DequeueWithOptions(messages []Message, opts *DeqOptions) (int, e
 				return fmt.Errorf("next: %w", err)
 			}
 			s, _ := dest[0].(string)
-			// fmt.Println("Dequeue:", s)
 			if logger != nil {
 				logger.Debug("Dequeue", "name", Q.name, "size", s, "dest", dest[0])
 			}
@@ -397,8 +395,8 @@ func (Q *Queue) DequeueWithOptions(messages []Message, opts *DeqOptions) (int, e
 				err = nil
 			case 24010: // 0RA-24010: Queue does not exist
 				Q.Close()
-				// case 25263: // ORA-25263: no message in queue with message ID
-				// return 0, nil
+				//case 25263: // ORA-25263: no message in queue with message ID
+				//return 0, nil
 			case 25226: // ORA-25226: dequeue failed, queue <owner>.<queue_name> is not enabled for dequeue
 				if startErr := Q.start(); startErr != nil {
 					return 0, fmt.Errorf("%w: %w", startErr, err)
@@ -446,7 +444,6 @@ func (Q *Queue) execQ(ctx context.Context, qry string) error {
 	}
 	return nil
 }
-
 func (Q *Queue) start() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -582,7 +579,6 @@ func (M Message) Deadline() time.Time {
 	}
 	return M.Enqueued.Add(M.Delay + M.Expiration)
 }
-
 func (M *Message) toOra(d *drv, props *C.dpiMsgProps) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -861,7 +857,7 @@ func (D *DeqOptions) fromOra(d *drv, opts *C.dpiDeqOptions) error {
 	D.MsgID = nil
 	if OK(C.dpiDeqOptions_getMsgId(opts, &value, &length), "getMsgId") {
 		if length != 0 {
-			// D.MsgID = ((*[1 << 30]byte)(unsafe.Pointer(value)))[:int(length):int(length)]
+			//D.MsgID = ((*[1 << 30]byte)(unsafe.Pointer(value)))[:int(length):int(length)]
 			D.MsgID = ([]byte)(unsafe.Slice((*byte)(unsafe.Pointer(value)), length))
 		}
 	}


### PR DESCRIPTION
Refs #382 

The `messages` slice is only adjusted if `0 < num && num < len(messages)`, so for the case where the `SELECT` returns 0, then it still try to dequeue with the original length, leading to the memory leak.

My proposed solution:
If `num == 0`, set the `messages = messages[:1]` so that `deqOne` is used, which does not cause a leak. This would still allow `Dequeue` to block for the set `Wait` time.
