### PR TITLE
bool pointers set to nil should set database field to null not 0.

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -1281,9 +1281,11 @@ func (st *statement) bindVarTypeSwitch(ctx context.Context, info *argInfo, get *
 	case bool, []bool:
 		if st.dpiStmtInfo.isPLSQL == 1 || st.stmtOptions.boolString.IsZero() || st.PlSQLArrays() {
 			info.typ, info.natTyp = C.DPI_ORACLE_TYPE_BOOLEAN, C.DPI_NATIVE_TYPE_BOOLEAN
-			info.set = dataSetBool
-			if info.isOut {
-				*get = dataGetBool
+			if !nilPtr {
+				info.set = dataSetBool
+				if info.isOut {
+					*get = dataGetBool
+				}
 			}
 		} else {
 			info.typ, info.natTyp = C.DPI_ORACLE_TYPE_VARCHAR, C.DPI_NATIVE_TYPE_BYTES


### PR DESCRIPTION
When setting a *bool to nil, 0 is being inserted into the database instead of null. This adds support for inserting nulls into the database when using *bool.

This is demonstrated using the provided test called TestBoolValueTypes which contains several tests with different Boolean types. 