### PR TITLE
Expose timestamp precision as precision

### DIFF
--- a/orahlp.go
+++ b/orahlp.go
@@ -326,11 +326,15 @@ func DescribeQuery(ctx context.Context, db Execer, qry string) ([]QueryColumn, e
 		r := dR.(*rows)
 		cols = make([]QueryColumn, len(r.columns))
 		for i, col := range r.columns {
+			precision := int(col.Precision)
+			if precision == 0 && col.FsPrecision != 0 {
+				precision = int(col.FsPrecision)
+			}
 			cols[i] = QueryColumn{
 				Name:      col.Name,
 				Type:      int(col.OracleType),
 				Length:    int(col.Size),
-				Precision: int(col.Precision),
+				Precision: int(precision),
 				Scale:     int(col.Scale),
 				Nullable:  col.Nullable,
 			}

--- a/rows.go
+++ b/rows.go
@@ -220,6 +220,8 @@ func (r *rows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok b
 		//C.DPI_ORACLE_TYPE_NATIVE_UINT, C.DPI_NATIVE_TYPE_UINT64,
 		C.DPI_ORACLE_TYPE_NUMBER:
 		return int64(col.Precision), int64(col.Scale), true
+	case C.DPI_ORACLE_TYPE_TIMESTAMP, C.DPI_ORACLE_TYPE_TIMESTAMP_TZ, C.DPI_ORACLE_TYPE_TIMESTAMP_LTZ:
+		return int64(col.FsPrecision), 0, true
 	default:
 		return 0, 0, false
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -3427,6 +3427,7 @@ func (st *statement) openRows(ctx context.Context, colCount int) (*rows, error) 
 			Size:             ti.clientSizeInBytes,
 			Precision:        ti.precision,
 			Scale:            ti.scale,
+			FsPrecision:      ti.fsPrecision,
 			Nullable:         info.nullOk == 1,
 			ObjectType:       ti.objectType,
 			SizeInChars:      ti.sizeInChars,
@@ -3475,6 +3476,7 @@ type Column struct {
 	Size, SizeInChars, DBSize  C.uint32_t
 	Precision                  C.int16_t
 	Scale                      C.int8_t
+	FsPrecision                C.uint8_t
 	Nullable                   bool
 	DomainAnnotation
 	VectorDimensions C.uint32_t


### PR DESCRIPTION
We were trying to figure out the unit of returned timestamp columns and noticed that ODPI stores it under a different field than numeric precision. On the database/sql side there is no separate field so fold them together.