### PR TITLE
Fix several small issues from code review

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -149,7 +149,7 @@ func (c *conn) Break() error {
 	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("Break", "dpiConn", c.dpiConn)
 	}
@@ -433,7 +433,7 @@ func (c *conn) newVar(vi varInfo) (*C.dpiVar, []C.dpiData, error) {
 	}
 	var dataArr *C.dpiData
 	var v *C.dpiVar
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("dpiConn_newVar", "conn", c.dpiConn, "typ", int(vi.Typ), "natTyp", int(vi.NatTyp), "sliceLen", vi.SliceLen, "bufSize", vi.BufSize, "isArray", isArray, "objType", vi.ObjectType, "v", v)
 	}
@@ -496,7 +496,7 @@ func (c *conn) init(ctx context.Context, isNew bool, onInit func(ctx context.Con
 }
 
 func (c *conn) initTZ() error {
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("initTZ", "tzValid", c.tzValid, "paramsTZ", c.params.Timezone)
 	}
@@ -626,7 +626,7 @@ func maybeBadConn(err error, c *conn) error {
 		return nil
 	}
 	cl := func() {}
-	ctx := context.TODO()
+	ctx := context.Background()
 	logger := getLogger(ctx)
 	if c != nil {
 		cl = func() {
@@ -717,7 +717,10 @@ func (c *conn) setTraceTag(tt TraceTag) error {
 		return nil
 	}
 	todo := make([][2]string, 0, 5)
-	currentTT, _ := c.currentTT.Load().(TraceTag)
+	var currentTT TraceTag
+	if v, ok := c.currentTT.Load().(TraceTag); ok {
+		currentTT = v
+	}
 	for nm, vv := range map[string][2]string{
 		"action":     {currentTT.Action, tt.Action},
 		"module":     {currentTT.Module, tt.Module},
@@ -973,7 +976,7 @@ func (c *conn) IsValid() bool {
 	if dpiConnOK {
 		dpiConnOK = c.isHealthy()
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("IsValid", "connOK", dpiConnOK, "released", released, "pooled", pooled, "tzOK", tzOK)
 	}

--- a/data.go
+++ b/data.go
@@ -159,7 +159,7 @@ func (d *Data) GetInt64() int64 {
 	}
 	//i := C.dpiData_getInt64(&d.dpiData)
 	i := *((*int64)(unsafe.Pointer(&d.dpiData.value)))
-	if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("GetInt64", "data", d, "p", fmt.Sprintf("%p", d), "i", i)
 	}
 
@@ -393,7 +393,7 @@ type IntervalYM struct {
 
 // Get returns the contents of Data.
 func (d *Data) Get() any {
-	// if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	// if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 	// 	 logger.Debug("Get", "data", fmt.Sprintf("%#v", d), "p", fmt.Sprintf("%p", d))
 	// }
 	switch d.NativeTypeNum {
@@ -524,13 +524,13 @@ func (d *Data) Set(v any) error {
 	//d.NativeTypeNum = C.DPI_NATIVE_TYPE_ROWID
 	//d.SetRowid(x)
 	default:
-		if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+		if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 			logger.Debug("Set", "data", d, "type", fmt.Sprintf("%T", v))
 		}
 
 		return fmt.Errorf("data Set type %T: %w", v, ErrNotSupported)
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("Set", "data", d)
 	}

--- a/drv.go
+++ b/drv.go
@@ -325,7 +325,7 @@ func (d *drv) init(configDir, libDir string) error {
 			ctxParams.oracleClientLibDir = C.CString(libDir)
 		}
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if logger != nil {
 		logger.Debug("dpiContext_createWithParams", "params", ctxParams)
 	}
@@ -493,7 +493,11 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 				cleanup()
 			}
 			if c != nil && c.dpiConn != nil {
-				fmt.Printf("ERROR: conn %p of createConn is not Closed!\n", c)
+				if logger := getLogger(context.Background()); logger != nil {
+					logger.Error("conn of createConn is not Closed!", "conn", fmt.Sprintf("%p", c))
+				} else {
+					fmt.Printf("ERROR: conn %p of createConn is not Closed!\n", c)
+				}
 				_ = c.closeNotLocking()
 			}
 		})
@@ -505,7 +509,11 @@ func (d *drv) createConn(pool *connPool, P commonAndConnParams) (*conn, bool, er
 				cleanup()
 			}
 			if c != nil && c.dpiConn != nil {
-				fmt.Printf("ERROR: conn %p of createConn is not Closed!\n%s\n", c, stack)
+				if logger := getLogger(context.Background()); logger != nil {
+					logger.Error("conn of createConn is not Closed!", "conn", fmt.Sprintf("%p", c), "stack", string(stack))
+				} else {
+					fmt.Printf("ERROR: conn %p of createConn is not Closed!\n%s\n", c, stack)
+				}
 				_ = c.closeNotLocking()
 			}
 		})
@@ -938,7 +946,7 @@ func (d *drv) createPool(P commonAndPoolParams) (*connPool, error) {
 	// create pool
 	var dp *C.dpiPool
 	logger := P.Logger
-	if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("C.dpiPool_create",
 			"user", P.Username,
 			"ConnectString", P.ConnectString,

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -357,7 +357,7 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 		q.Add("poolMaxSessions", strconv.Itoa(P.MaxSessions))
 	}
 	if P.MaxSessionsPerShard != 0 {
-		q.Add("poolMasSessionsPerShard", strconv.Itoa(P.MaxSessionsPerShard))
+		q.Add("poolMaxSessionsPerShard", strconv.Itoa(P.MaxSessionsPerShard))
 	}
 	q.Add("poolIncrement", strconv.Itoa(P.SessionIncrement))
 	if P.AdminRole != "" {
@@ -632,9 +632,9 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 	}{
 		{&P.MinSessions, "poolMinSessions"},
 		{&P.MaxSessions, "poolMaxSessions"},
-		{&P.MaxSessionsPerShard, "poolMasSessionsPerShard"},
+		{&P.MaxSessionsPerShard, "poolMaxSessionsPerShard"},
 		{&P.SessionIncrement, "poolIncrement"},
-		{&P.SessionIncrement, "sessionIncrement"},
+		{&P.SessionIncrement, "sessionIncrement"}, // backwards-compat alias for poolIncrement; if both present, sessionIncrement wins
 		{&P.StmtCacheSize, "stmtCacheSize"},
 	} {
 		s := q.Get(task.Key)

--- a/json.go
+++ b/json.go
@@ -341,7 +341,7 @@ func (j JSON) GetValue(opts JSONOption) (any, error) {
 	} else {
 		return val, nil
 	}
-	if logger := getLogger(context.TODO()); logger != nil {
+	if logger := getLogger(context.Background()); logger != nil {
 		logger.Error("JSON.GetValue", "error", err)
 	}
 	return nil, err
@@ -357,7 +357,7 @@ func (j JSON) String() string {
 	if err == nil {
 		return s
 	}
-	if logger := getLogger(context.TODO()); logger != nil {
+	if logger := getLogger(context.Background()); logger != nil {
 		logger.Error("JSON.String", "error", err)
 	}
 	return ""
@@ -432,11 +432,19 @@ func (j JSONScalar) GetValue() (val any, err error) {
 	} else {
 		val = d.Get()
 		if j.dpiJsonNode.oracleTypeNum == C.DPI_ORACLE_TYPE_JSON_OBJECT {
-			jobj := val.(JSONObject)
+			jobj, ok := val.(JSONObject)
+			if !ok {
+				err = fmt.Errorf("expected JSONObject, got %T", val)
+				return
+			}
 			jobj.stringOption = j.stringOption
 			val, err = jobj.GetValue()
 		} else if j.dpiJsonNode.oracleTypeNum == C.DPI_ORACLE_TYPE_JSON_ARRAY {
-			jarr := val.(JSONArray)
+			jarr, ok := val.(JSONArray)
+			if !ok {
+				err = fmt.Errorf("expected JSONArray, got %T", val)
+				return
+			}
 			jarr.stringOption = j.stringOption
 			val, err = jarr.GetValue()
 		} else {

--- a/obj.go
+++ b/obj.go
@@ -51,7 +51,7 @@ var ErrNoSuchKey = errors.New("no such key")
 // GetAttribute gets the i-th attribute into data.
 func (O *Object) GetAttribute(data *Data, name string) error {
 	if O == nil {
-		panic("nil Object")
+		return errors.New("nil Object")
 	}
 	attr, ok := O.Attributes[name]
 	if !ok {
@@ -75,7 +75,7 @@ func (O *Object) GetAttribute(data *Data, name string) error {
 	}); err != nil {
 		return fmt.Errorf("getAttributeValue(%q, obj=%s, attr=%+v, typ=%d): %w", name, O.Name, attr.dpiObjectAttr, data.NativeTypeNum, err)
 	}
-	if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("getAttributeValue", "dpiObject", fmt.Sprintf("%p", O.dpiObject),
 			attr.Name, fmt.Sprintf("%p", attr.dpiObjectAttr),
 			"nativeType", data.NativeTypeNum, "oracleType", attr.OracleTypeNum,
@@ -99,7 +99,7 @@ func (O *Object) SetAttribute(name string, data *Data) error {
 		}
 		// name = try
 	}
-	// ctx := context.TODO()
+	// ctx := context.Background()
 	// logger := getLogger(ctx)
 	// if logger != nil {
 	// 	logger = logger.With("object", O.Name, "name", name)
@@ -126,7 +126,7 @@ func (O *Object) SetAttribute(name string, data *Data) error {
 		C.dpiObjectAttr_getInfo(attr.dpiObjectAttr, &info)
 		return fmt.Errorf("dpiObject_setAttributeValue NativeTypeNum=%d ObjectType=%v typeInfo=%+v: %w", data.NativeTypeNum, data.ObjectType, info.typeInfo, err)
 	}
-	// if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	// if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 	// 	logger.Debug("setAttributeValue", "dpiObject", fmt.Sprintf("%p", O.dpiObject),
 	// 		attr.Name, fmt.Sprintf("%p", attr.dpiObjectAttr),
 	// 		"nativeType", data.NativeTypeNum, "oracleType", attr.OracleTypeNum,
@@ -258,8 +258,8 @@ func (O *Object) Close() error {
 		return nil
 	}
 	// fmt.Printf("Object.Close0 %p\n", O.dpiObject)
-	logger := getLogger(context.TODO())
-	if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	logger := getLogger(context.Background())
+	if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("Object.Close", "object", fmt.Sprintf("%p", O.dpiObject))
 	}
 
@@ -282,7 +282,7 @@ func (O *Object) Close() error {
 			if obj == nil || obj.dpiObject == nil {
 				continue
 			}
-			if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+			if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 				logger.Debug("ObjectCollection.Close close item", "idx", curr, "object", fmt.Sprintf("%p", obj))
 			}
 			// fmt.Printf("Close obj=%p\n", obj.dpiObject)
@@ -307,7 +307,7 @@ func (O *Object) Close() error {
 			if obj == nil {
 				return nil
 			}
-			if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+			if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 				logger.Debug("Object.Close close sub-object", "attribute", a.Name, "object", fmt.Sprintf("%p", obj))
 			}
 
@@ -341,7 +341,7 @@ func (O *Object) AsMap(recursive bool) (map[string]any, error) {
 	if O == nil || O.dpiObject == nil {
 		return nil, nil
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	m := make(map[string]any, len(O.ObjectType.Attributes))
 	data := scratch.Get()
 	defer scratch.Put(data)
@@ -357,7 +357,7 @@ func (O *Object) AsMap(recursive bool) (map[string]any, error) {
 			d = maybeString(d, ot.ObjectType)
 		}
 		m[a] = d
-		if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+		if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 			logger.Debug("AsMap", "attribute", a, "data", fmt.Sprintf("%#v", d), "type", fmt.Sprintf("%T", d), "recursive", recursive)
 		}
 		if !recursive {
@@ -487,7 +487,7 @@ func (O ObjectCollection) FromSlice(v []any) error {
 	if O.dpiObject == nil {
 		return nil
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 
 	data := scratch.Get()
 
@@ -512,14 +512,14 @@ func (O *Object) FromMap(recursive bool, m map[string]any) error {
 	if O == nil || O.dpiObject == nil {
 		return nil
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 
 	for a, ot := range O.ObjectType.Attributes {
 		v := m[a]
 		if v == nil {
 			continue
 		}
-		if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+		if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 			logger.Debug("FromMap", "attribute", a, "value", v, "type", fmt.Sprintf("%T", v), "recursive", recursive, "ot", ot.ObjectType)
 		}
 		if ot.ObjectType.CollectionOf != nil { // Collection case
@@ -595,7 +595,7 @@ func (O *Object) FromJSON(dec *json.Decoder) error {
 		return err
 	}
 	wantDelim := tok == json.Delim('{')
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	first := true
 	for {
 		if first && wantDelim || !first {
@@ -618,7 +618,7 @@ func (O *Object) FromJSON(dec *json.Decoder) error {
 				k = k2
 			}
 		}
-		if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+		if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 			logger.Debug("attribute", "k", k, "a", a)
 		}
 		if !ok {
@@ -676,10 +676,10 @@ func (O ObjectCollection) FromMapSlice(recursive bool, m []map[string]any) error
 	if O.Object == nil || O.dpiObject == nil {
 		return nil
 	}
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 
 	for i, o := range m {
-		if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+		if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 			logger.Debug("FromMapSlice", "index", i, "recursive", recursive)
 		}
 		elt, err := O.ObjectType.CollectionOf.NewObject()
@@ -886,7 +886,7 @@ func (O ObjectCollection) GetItem(data *Data, i int) error {
 		return ErrNotCollection
 	}
 	if data == nil {
-		panic("data cannot be nil")
+		return errors.New("data cannot be nil")
 	}
 
 	runtime.LockOSThread()
@@ -1163,7 +1163,7 @@ func (t *ObjectType) NewObject() (*Object, error) {
 	if t == nil {
 		return nil, errNilObjectType
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	logger := getLogger(ctx)
 	if logger != nil && logger.Enabled(ctx, slog.LevelDebug) {
 		logger.Debug("NewObject", "name", t.Name)
@@ -1224,7 +1224,7 @@ func (t *ObjectType) Close() error {
 		return nil
 	}
 
-	logger := getLogger(context.TODO())
+	logger := getLogger(context.Background())
 	if cof != nil {
 		if err := cof.Close(); err != nil && logger != nil {
 			logger.Error("ObjectType.Close CollectionOf.Close", "name", t.Name, "collectionOf", cof.Name, "error", err)
@@ -1237,7 +1237,7 @@ func (t *ObjectType) Close() error {
 		}
 	}
 
-	if logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("ObjectType.Close", "name", t.Name)
 	}
 	if err := drv.checkExec(func() C.int {
@@ -1274,7 +1274,7 @@ func wrapObject(c *conn, objectType *C.dpiObjectType, object *C.dpiObject) (*Obj
 
 func (t *ObjectType) init(cache map[string]*ObjectType) error {
 	if t.drv == nil {
-		panic("conn is nil")
+		return errors.New("conn is nil")
 	}
 	if t.Name != "" && t.Attributes != nil && t.NativeTypeNum != 0 {
 		return nil
@@ -1313,7 +1313,7 @@ func (t *ObjectType) init(cache map[string]*ObjectType) error {
 			C.dpiObjectType_addRef(t.CollectionOf.dpiObjectType)
 		}
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	logger := getLogger(ctx)
 	if logger != nil && logger.Enabled(ctx, slog.LevelDebug) {
 		logger.Debug("ObjectType.init", "schema", t.Schema, "package", t.PackageName, "name", t.Name, "isColl", info.isCollection, "numAttrs", info.numAttributes, "info", fmt.Sprintf("%+v", info))

--- a/orahlp.go
+++ b/orahlp.go
@@ -39,7 +39,7 @@ type intType struct{}
 
 func (intType) String() string { return "Int64" }
 func (intType) ConvertValue(v any) (driver.Value, error) {
-	if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("ConvertValue Int64", "value", v)
 	}
 	switch x := v.(type) {
@@ -91,7 +91,7 @@ type floatType struct{}
 
 func (floatType) String() string { return "Float64" }
 func (floatType) ConvertValue(v any) (driver.Value, error) {
-	if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("ConvertValue Float64", "value", v)
 	}
 	switch x := v.(type) {
@@ -137,7 +137,7 @@ type numType struct{}
 
 func (numType) String() string { return "Num" }
 func (numType) ConvertValue(v any) (driver.Value, error) {
-	if logger := getLogger(context.TODO()); logger != nil && logger.Enabled(context.TODO(), slog.LevelDebug) {
+	if logger := getLogger(context.Background()); logger != nil && logger.Enabled(context.Background(), slog.LevelDebug) {
 		logger.Debug("ConvertValue Num", "value", v)
 	}
 	switch x := v.(type) {

--- a/token.go
+++ b/token.go
@@ -37,7 +37,7 @@ func TokenCallbackHandler(handle C.uintptr_t, accessToken *C.dpiAccessToken) {
 	tokenCB := h.Value().(accessTokenCB)
 	ctx := tokenCB.ctx
 	if ctx == nil {
-		ctx = context.TODO()
+		ctx = context.Background()
 	}
 	logger := getLogger(ctx)
 	if logger != nil && logger.Enabled(ctx, slog.LevelDebug) {


### PR DESCRIPTION
Critical fixes:
- subscr.go: Fix race condition in NewSubscription where subscriptionsID was read without the lock after unlock; capture localID before Unlock() to avoid the window where another goroutine could increment the counter.
- subscr.go: Fix C memory leaks — subscrID (C.malloc'd callback context) was never freed on dpiConn_subscribe error path or in Subscription.Close(). Added subscrID field to Subscription struct; free on both error and close. Also clean up subscriptions map on error path.
- lob.go: Guard all &p[0] dereferences against empty slices at five sites: dpiLobReader.ReadAt, dpiLobWriter.Write, DirectLob.Set, DirectLob.ReadAt, DirectLob.WriteAt. DirectLob.Set uses a nil *C.char for empty input to correctly clear the LOB rather than panicking.

High severity fixes:
- dsn/dsn.go: Fix typo poolMasSessionsPerShard -> poolMaxSessionsPerShard in both serialization (q.Add) and deserialization (parser table). The documented DSN parameter was silently ignored due to the missing 'x'.
- rows.go: Restore statement handle cleanup on getNumQueryColumns error path in both Next() and NextResultSet(). Replace commented-out C.dpiStmt_release calls with st.Close(), consistent with the openRows error path.
- obj.go: Replace panic() with error returns in three public API methods: GetAttribute (nil Object), GetItem (nil data), and ObjectType.init (nil drv). A library must never crash the caller process on bad input.
- json.go: Replace unchecked type assertions val.(JSONObject) and val.(JSONArray) with safe comma-ok assertions that return a descriptive error instead of panicking on unexpected types from d.Get().

Medium severity fixes:
- dsn/dsn.go: Document that sessionIncrement is a backwards-compat alias for poolIncrement; if both keys are present, sessionIncrement wins (order-dependent).
- drv.go, queue.go: Replace fmt.Printf in resource-leak finalizers with getLogger(context.Background()), falling back to fmt.Printf only when no logger is configured. Leak warnings now respect the configured log handler.
- conn.go: Replace discarded ok bool in atomic.Value type assertion (c.currentTT.Load().(TraceTag)) with explicit comma-ok check. Zero-value TraceTag remains the correct fallback but intent is now explicit.
- conn.go, data.go, drv.go, json.go, lob.go, obj.go, orahlp.go, queue.go, rows.go, subscr.go, token.go: Replace all 40+ context.TODO() occurrences with context.Background(). These are all logger-only call sites with no real context available; Background() is the correct semantic ("intentionally no deadline") vs TODO() ("known placeholder"). log.go is intentionally unchanged as it contains the ctx != context.TODO() special-case guard.