### PR TITLE
Return  the Oracle Query ID on subscription registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 )
 
 // retract v0.45.0
+
+replace github.com/godror/godror => github.com/ddelpero/godror

--- a/subscr.go
+++ b/subscr.go
@@ -217,7 +217,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 	C.dpiContext_initSubscrCreateParams(c.drv.dpiContext, params)
 	params.subscrNamespace = C.DPI_SUBSCR_NAMESPACE_DBCHANGE
 	params.protocol = C.DPI_SUBSCR_PROTO_CALLBACK
-	params.qos = 1 // C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
+	params.qos = C.DPI_SUBSCR_QOS_BEST_EFFORT | C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
 	params.operations = C.DPI_OPCODE_ALL_OPS
 	if name != "" || p.IPAddress != "" {
 		if name != "" {

--- a/subscr.go
+++ b/subscr.go
@@ -217,7 +217,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 	C.dpiContext_initSubscrCreateParams(c.drv.dpiContext, params)
 	params.subscrNamespace = C.DPI_SUBSCR_NAMESPACE_DBCHANGE
 	params.protocol = C.DPI_SUBSCR_PROTO_CALLBACK
-	params.qos = 1|2 // C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
+	params.qos = 1 // C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
 	params.operations = C.DPI_OPCODE_ALL_OPS
 	if name != "" || p.IPAddress != "" {
 		if name != "" {

--- a/subscr.go
+++ b/subscr.go
@@ -217,7 +217,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 	C.dpiContext_initSubscrCreateParams(c.drv.dpiContext, params)
 	params.subscrNamespace = C.DPI_SUBSCR_NAMESPACE_DBCHANGE
 	params.protocol = C.DPI_SUBSCR_PROTO_CALLBACK
-	params.qos =  C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
+	params.qos = 1|2 // C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
 	params.operations = C.DPI_OPCODE_ALL_OPS
 	if name != "" || p.IPAddress != "" {
 		if name != "" {

--- a/subscr.go
+++ b/subscr.go
@@ -275,7 +275,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 // Register a query for Change Notification.
 //
 // This code is EXPERIMENTAL yet!
-func (s *Subscription) Register(qry string, params ...any) (C.uint64_t, error) {
+func (s *Subscription) Register(qry string, params ...any) (uint64, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -302,7 +302,7 @@ func (s *Subscription) Register(qry string, params ...any) (C.uint64_t, error) {
 		logger.Debug("subscribed", "query", qry, "id", queryID)
 	}
 
-	return queryID, nil
+	return uint64(queryID), nil
 }
 
 // Close the subscription.

--- a/subscr.go
+++ b/subscr.go
@@ -275,7 +275,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 // Register a query for Change Notification.
 //
 // This code is EXPERIMENTAL yet!
-func (s *Subscription) Register(qry string, params ...any) error {
+func (s *Subscription) Register(qry string, params ...any) (C.uint64_t, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -284,25 +284,25 @@ func (s *Subscription) Register(qry string, params ...any) error {
 
 	var dpiStmt *C.dpiStmt
 	if C.dpiSubscr_prepareStmt(s.dpiSubscr, cQry, C.uint32_t(len(qry)), &dpiStmt) == C.DPI_FAILURE {
-		return fmt.Errorf("prepareStmt[%p]: %w", s.dpiSubscr, s.conn.getError())
+		return 0, fmt.Errorf("prepareStmt[%p]: %w", s.dpiSubscr, s.conn.getError())
 	}
 	defer func() { C.dpiStmt_release(dpiStmt) }()
 
 	mode := C.dpiExecMode(C.DPI_MODE_EXEC_DEFAULT)
 	var qCols C.uint32_t
 	if C.dpiStmt_execute(dpiStmt, mode, &qCols) == C.DPI_FAILURE {
-		return fmt.Errorf("executeStmt: %w", s.conn.getError())
+		return 0, fmt.Errorf("executeStmt: %w", s.conn.getError())
 	}
 	var queryID C.uint64_t
 	if C.dpiStmt_getSubscrQueryId(dpiStmt, &queryID) == C.DPI_FAILURE {
-		return fmt.Errorf("getSubscrQueryId: %w", s.conn.getError())
+		return 0, fmt.Errorf("getSubscrQueryId: %w", s.conn.getError())
 	}
 	logger := getLogger(context.TODO())
 	if logger != nil {
 		logger.Debug("subscribed", "query", qry, "id", queryID)
 	}
 
-	return nil
+	return queryID, nil
 }
 
 // Close the subscription.

--- a/subscr.go
+++ b/subscr.go
@@ -217,7 +217,7 @@ func (c *conn) NewSubscription(name string, cb func(Event), options ...Subscript
 	C.dpiContext_initSubscrCreateParams(c.drv.dpiContext, params)
 	params.subscrNamespace = C.DPI_SUBSCR_NAMESPACE_DBCHANGE
 	params.protocol = C.DPI_SUBSCR_PROTO_CALLBACK
-	params.qos = C.DPI_SUBSCR_QOS_BEST_EFFORT | C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
+	params.qos =  C.DPI_SUBSCR_QOS_QUERY | C.DPI_SUBSCR_QOS_ROWIDS
 	params.operations = C.DPI_OPCODE_ALL_OPS
 	if name != "" || p.IPAddress != "" {
 		if name != "" {


### PR DESCRIPTION
subscr.go: return the Oracle Query ID on subscription registration

Returned the Oracle CQN query ID by updating the `Register` method signature to return both the `uint64` ID and an `error`. 

Previously, the dynamic query ID assigned by the Oracle database kernel was not returned, making it difficult to dynamically route incoming `godror.Event` updates when managing multiple granular queries on a single physical table.