### PR TITLE
Use `${SRCDIR}` instead of relative path for `#cgo CFLAGS` to resolve include files

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -68,7 +68,7 @@
 package godror
 
 /*
-#cgo CFLAGS: -I./odpi/include -I./odpi/src -I./odpi/embed
+#cgo CFLAGS: -I${SRCDIR}/odpi/include -I${SRCDIR}/odpi/src -I${SRCDIR}/odpi/embed
 
 #include "dpi.c"
 


### PR DESCRIPTION
With the current `-I./odpi/src` etc., build fails if we invoke the compiler from directories other than the godror source root. The issue happens when we try to build godror using [pantsbuild](https://www.pantsbuild.org):

```
gopath/pkg/mod/github.com/godror/godror@v0.50.0/lob.go:9:10: fatal error: 'dpiImpl.h' file not found
    9 | #include "dpiImpl.h"
      |          ^~~~~~~~~~~
```

In our case, `go tool cgo` is invoked for godror sources residing in `gopath/pkg/mod/github.com/godror/godror@v0.50.0` from the current directory (pantsbuild-created sandbox directory) with `-I./odpi/src`. With this patch, the include path becomes `${sandbox_dir}/gopath/pkg/mod/github.com/godror/godror@v0.50.0/odpi/src` and makes the build succeed in situations like ours.