### PR TITLE
fix(conn): don't leak pooled session on bad-conn close; keep session in IsValid

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -633,6 +633,13 @@ func maybeBadConn(err error, c *conn) error {
 			if logger != nil {
 				logger.Error("maybeBadConn close", "conn", c, "error", err)
 			}
+			// dpiConn_close before release so an orphaned dpiStmt (abandoned by
+			// database/sql on a force-closed conn) can't pin the pooled session busy
+			// forever (ORA-24496, #415). Only the bad-conn path hard-closes; healthy
+			// Close keeps the plain release (queues/LOBs outlive the conn via refcount).
+			if c.dpiConn != nil {
+				C.dpiConn_close(c.dpiConn, C.DPI_MODE_CONN_CLOSE_DEFAULT, nil, 0)
+			}
 			_ = c.closeNotLocking()
 		}
 	}
@@ -961,8 +968,8 @@ func (c *conn) ResetSession(ctx context.Context) error {
 // If implemented, drivers may return the underlying error from queries,
 // even if the connection should be discarded by the connection pool.
 //
-// This implementation returns the underlying session to the OCI session pool,
-// iff this is a pooled connection. ResetSession will reacquire it.
+// A pooled connection keeps its session so it stays reusable; the session
+// returns to the OCI pool only when the connection is closed.
 func (c *conn) IsValid() bool {
 	if c == nil {
 		return false
@@ -988,16 +995,6 @@ func (c *conn) IsValid() bool {
 		return dpiConnOK
 	}
 
-	// FIXME(tgulacsi): Prepared statements hold the previous session,
-	// so sometimes sessions are not released, resulting in
-	//
-	//     ORA-24459: OCISessionGet()
-	//
-	// See https://github.com/godror/godror/issues/57 for example.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	_ = c.closeNotLocking()
-	c.released = true
 	return true
 }
 

--- a/z_i415_test.go
+++ b/z_i415_test.go
@@ -1,0 +1,59 @@
+package godror_test
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/godror/godror"
+	"github.com/godror/godror/dsn"
+)
+
+// TestPoolLeakOnCancel reproduces the ORA-24496 pool leak: a query cancelled
+// mid-execute must not pin its pooled session.
+func TestPoolLeakOnCancel(t *testing.T) {
+	P, err := dsn.Parse(testConStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	P.StandaloneConnection = godror.Bool(false)
+	P.PoolParams.MinSessions, P.PoolParams.MaxSessions = 2, 4
+	P.PoolParams.WaitTimeout = 3 * time.Second
+
+	db := sql.OpenDB(godror.NewConnector(P))
+	defer db.Close()
+	db.SetMaxOpenConns(P.PoolParams.MaxSessions)
+
+	ctx, cancel := context.WithTimeout(testContext("PoolLeakOnCancel"), time.Minute)
+	defer cancel()
+
+	probe := func(ctx context.Context) error {
+		var n int
+		return db.QueryRowContext(ctx, "SELECT 1 FROM DUAL").Scan(&n)
+	}
+	if err := probe(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cctx, ccancel := context.WithTimeout(ctx, time.Duration(1+i%20)*time.Millisecond)
+			defer ccancel()
+			_, _ = db.ExecContext(cctx, "BEGIN DBMS_SESSION.SLEEP(1); END;")
+		}(i)
+	}
+	wg.Wait()
+
+	pctx, pcancel := context.WithTimeout(ctx, 15*time.Second)
+	defer pcancel()
+	for i := 0; i < 3; i++ {
+		if err := probe(pctx); err != nil {
+			t.Fatalf("pool did not recover after cancelled queries: %+v", err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #415. 

Cancelled queries can pin a pooled session as busy forever -> ORA-24496 on every subsequent acquire, unrecoverable without a restart. Also surfaces as "driver: bad connection" under pool contention.

Test: TestPoolLeakOnCancel. StandaloneConnection=true is unaffected.