### PR TITLE
Do not read or close the connection from the BREAK path unlocked

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -160,7 +160,12 @@ func (c *conn) Break() error {
 		if logger != nil {
 			logger.Error("Break", "error", err)
 		}
-		return maybeBadConn(fmt.Errorf("Break: %w", err), c)
+		// Only classify the error here: Break holds c.mu.RLock, and
+		// maybeBadConn with a non-nil conn would release the connection
+		// under the read lock while another goroutine may be inside an
+		// ODPI call on it. The owner of the statement closes the
+		// connection on driver.ErrBadConn.
+		return maybeBadConn(fmt.Errorf("Break: %w", err), nil)
 	}
 	return nil
 }

--- a/stmt.go
+++ b/stmt.go
@@ -767,9 +767,12 @@ func (st *statement) queryContextNotLocked(ctx context.Context, args []driver.Na
 	// execute
 	var colCount C.uint32_t
 	f := func() C.int { return C.dpiStmt_execute(st.dpiStmt, mode, &colCount) }
+	// Capture the connection: the BREAK goroutine below may outlive this call
+	// by a moment, racing a concurrent statement Close that nils st.conn.
+	breakConn := st.conn
 	for i := 0; i < 3; i++ {
 		done := make(chan struct{})
-		if !st.conn.params.NoBreakOnContextCancel {
+		if !breakConn.params.NoBreakOnContextCancel {
 			// Forcefully BREAK execution on context cancelation
 			go func() {
 				select {
@@ -781,7 +784,7 @@ func (st *statement) queryContextNotLocked(ctx context.Context, args []driver.Na
 						if logger != nil {
 							logger.Warn("BREAK dpiStmt_execute")
 						}
-						st.conn.Break()
+						breakConn.Break()
 					}
 				}
 			}()


### PR DESCRIPTION
Harden the cancel path against a data race that `go test -race` reports under a storm of context cancelations.

- The BREAK goroutine started in `queryContextNotLocked` reads `st.conn` to call `Break()` on cancelation, but it can outlive the query call by a moment and race a concurrent `driverStmt.Close` that nils `st.conn` in `closeNotLocking`. Capture the connection into a local before starting the goroutine.
- `conn.Break` holds `c.mu.RLock`; on a `breakExecution` error it called `maybeBadConn(err, c)`, which releases the connection under the read lock while another goroutine may be inside an ODPI call on it. Only classify the error and let the statement owner close the connection on `driver.ErrBadConn`.

No functional change on the success path. Found and verified with `go test -race` under a cancelation storm; against a real database the race did not surface as a crash, so this is a correctness hardening rather than a fix for a specific abort.